### PR TITLE
add initial draft of data fetcher

### DIFF
--- a/python/utils/utils.py
+++ b/python/utils/utils.py
@@ -38,6 +38,7 @@ def fetch_tutorial_data(n_subjects=20, data_dir=None, resume=True, verbose=1):
     # set dataset url
     url = "https://box.bic.mni.mcgill.ca/s/wMPF2vj7EoYWELV"
 
+
     # set data_dir, if not directly set use ~ as default
     if data_dir is None:
         data_dir = str(Path.home())
@@ -72,18 +73,16 @@ def fetch_tutorial_data(n_subjects=20, data_dir=None, resume=True, verbose=1):
 
     # restrict demographic information to subset of subjects
     df_tmp = pd.read_csv(path_to_demographics)
-    df_tmp =  df_tmp[df_tmp['ID2'].isin(ids)]
-    df_tmp.to_csv(path_to_demographics, index=False)
+    df_tmp = df_tmp[df_tmp['ID2'].isin(ids)]
 
     # set download information for image files and download them
-    for hemi in ['lh', 'rh']:
-        image_files = _fetch_files(data_dir, [('{}_{}2fsaverage5_20.mgh'.format(subj, hemi),
-                                                 url + "/download?path=%2FSurfStat_tutorial_data%2Fthickness&files={}_{}2fsaverage5_20.mgh".format(subj, hemi),
-                                                {'move': '{}_{}2fsaverage5_20.mgh'.format(subj, hemi)}) for subj in ids])
+    # for hemi in ['lh', 'rh']:
+    image_files =_fetch_files(data_dir, [("thickness/{}_{}2fsaverage5_20.mgh".format(subj, hemi),
+                                  url + "/download?path=%2F&files=brainstat_tutorial.zip",
+                                 {"uncompress": True, "move": "brainstat_tutorial.zip"},)
+                              for subj in ids for hemi in ['lh', 'rh']
+                                            ],)
 
     # pack everything in a scikit-learn bunch and return it
-    return Bunch(demographics=path_to_demographics,
+    return Bunch(demographics=df_tmp,
                  image_files=image_files)
-
-
-

--- a/python/utils/utils.py
+++ b/python/utils/utils.py
@@ -1,0 +1,76 @@
+import warnings
+from pathlib import Path
+import pandas as pd
+from sklearn.utils import Bunch
+from nilearn.datasets.utils import (_get_dataset_dir, _fetch_files)
+
+
+def fetch_tutorial_data(n_subjects=20, data_dir=None, resume=True, verbose=1):
+
+    """Download and load the surfstat tutorial dataset.
+
+    Parameters
+    ----------
+    n_subjects: int, optional
+        The number of subjects to load from maximum of 100 subjects.
+        By default, 20 subjects will be loaded. If None is given,
+        all 100 subjects will be loaded.
+    data_dir: string, optional
+        Path of the data directory. Used to force data storage in a specified
+        location. If None, data will be download to ~ (home directory). Default: None
+    resume: bool, optional
+        If true, try resuming download if possible
+
+    Returns
+    -------
+    data: sklearn.datasets.base.Bunch
+        Dictionary-like object, the interest attributes are :
+         - 'surface_files': Paths to surface files in mgh format
+         - 'demographics': Path to CSV file containing demographic information
+
+    References
+    ----------
+
+    :Download: https://box.bic.mni.mcgill.ca/s/wMPF2vj7EoYWELV
+
+    """
+
+    url = "https://box.bic.mni.mcgill.ca/s/wMPF2vj7EoYWELV"
+
+    if data_dir is None:
+        data_dir = str(Path.home())
+
+    dataset_name = "brainstat_tutorial"
+
+    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir, verbose=verbose)
+
+    files = [
+        (
+            "brainstat_tutorial_df.csv",
+            url + "/download?path=%2FSurfStat_tutorial_data&files=myStudy.csv",
+            {"move": "brainstat_tutorial_df.csv"},
+        )
+    ]
+    path_to_demographics = _fetch_files(data_dir, files, verbose=verbose)[0]
+
+
+    ids = pd.read_csv(path_to_demographics)["ID2"].tolist()
+
+    max_subjects = len(ids)
+    if n_subjects is None:
+        n_subjects = max_subjects
+    if n_subjects > max_subjects:
+        warnings.warn('Warning: there are only %d subjects' % max_subjects)
+        n_subjects = max_subjects
+    ids = ids[:n_subjects]
+
+    for hemi in ['lh', 'rh']:
+        surface_files = _fetch_files(data_dir, [('{}_{}2fsaverage5_20.mgh'.format(subj, hemi),
+                                                 url + "/download?path=%2FSurfStat_tutorial_data%2Fthickness&files={}_{}2fsaverage5_20.mgh".format(subj, hemi),
+                                                {'move': '{}_{}2fsaverage5_20.mgh'.format(subj, hemi)}) for subj in ids])
+
+    return Bunch(demographics=path_to_demographics,
+                 surface_files=surface_files)
+
+
+


### PR DESCRIPTION
This PR adds the initial draft of the `data fetcher` functionality.
In more detail it interacts with the `surfstat` tutorial data that was uploaded to `BIC box` and is build upon [nilearn functions](https://nilearn.github.io/index.html).

Through the parameters users can modify the download in terms of 1) directory where data should be stored (`data_dir`) and 2) number of subjects that should be downloaded (`n_subjects`). The default directory is `~` and the default number of subjects is `20`. The output is a [scikit-learn bunch](https://scikit-learn.org/stable/modules/generated/sklearn.utils.Bunch.html) containing the paths to a) the `csv` file with demographic information and b) the `mgh` files. 
Here's an example call:

```
#fetch the data and save information into a variable
brainstat_tutorial_data = fetch_tutorial_data()

# check path of demographic information
brainstat_tutorial_data['demographics']

# check path of mgh files
brainstat_tutorial_data['image_files']
```


I tested it back and fourth and it appears to be working stable, however I plan to change the download function to use a compressed file instead of single files to save time and bandwidth.    

Addresses #16 