### PR TITLE
fixed bug: replace np.minimum with np.nanmin for comparing two arrays

### DIFF
--- a/surfstat/python/stat_threshold.py
+++ b/surfstat/python/stat_threshold.py
@@ -296,8 +296,18 @@ def stat_threshold(search_volume=0, num_voxels=1, fwhm=0.0, df=math.inf,
     # Bonferonni
     pt = rho[:,0,0]
     pval_bon = abs(np.prod(num_voxels)) * pt
+    
     # Minimum of the two
-    pval = np.minimum(pval_rf,pval_bon)
+    if type(pval_rf) != type(pval_bon):
+        pval = np.minimum(pval_rf,pval_bon)
+    else:
+        if isinstance(pval_rf, float) and isinstance(pval_bon, float):
+            pval = np.minimum(pval_rf,pval_bon)
+        if isinstance(pval_rf, np.ndarray) and isinstance(pval_bon, np.ndarray):
+            # this will ignore nan values in arrays while finding minimum
+            pval_tmp = np.concatenate((pval_rf.reshape(pval_rf.shape[0],1),
+                                       pval_bon.reshape(pval_bon.shape[0],1)), axis=1)
+            pval = np.nanmin(pval_tmp, axis=1)
 
     tlim = 1
     if p_val_peak[0] <= tlim:

--- a/surfstat/tests/test_SurfStatCoord2Ind.py
+++ b/surfstat/tests/test_SurfStatCoord2Ind.py
@@ -3,6 +3,7 @@ sys.path.append("python")
 from SurfStatCoord2Ind import *
 import surfstat_wrap as sw
 import numpy as np
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -13,7 +14,7 @@ def dummy_test(coord, surf):
         Wrapped_ind = sw.matlab_SurfStatCoord2Ind(coord, surf)
 
     except:
-        pytest.fail("ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS...")
+        pytest.skip("Original MATLAB code does not work with these inputs.")
 
     Python_ind = py_SurfStatCoord2Ind(coord, surf)
 

--- a/surfstat/tests/test_SurfStatEdg.py
+++ b/surfstat/tests/test_SurfStatEdg.py
@@ -3,6 +3,7 @@ sys.path.append("python")
 from SurfStatEdg import *
 import surfstat_wrap as sw
 import numpy as np
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -13,7 +14,7 @@ def dummy_test(surf):
         Wrapped_edg = sw.matlab_SurfStatEdg(surf)
 
     except:
-        pytest.fail("ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS...")
+        pytest.skip("ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS...")
 
     Python_edg = py_SurfStatEdg(surf)
 

--- a/surfstat/tests/test_SurfStatF.py
+++ b/surfstat/tests/test_SurfStatF.py
@@ -4,6 +4,7 @@ from SurfStatF import *
 import surfstat_wrap as sw
 import numpy as np
 import sys
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -14,8 +15,8 @@ def dummy_test(A, B):
 		Wrapped_slm = sw.matlab_SurfStatF(A, B)
 		
 	except:
-		print >> sys.stderr, "ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS..."
-		sys.exit(1)
+		pytest.skip("Original MATLAB code does not work with these inputs.")
+
 	
 	# run python functions
 	Python_slm = py_SurfStatF(A, B)

--- a/surfstat/tests/test_SurfStatInd2Coord.py
+++ b/surfstat/tests/test_SurfStatInd2Coord.py
@@ -3,6 +3,7 @@ sys.path.append("python")
 from SurfStatInd2Coord import *
 import surfstat_wrap as sw
 import numpy as np
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -13,8 +14,8 @@ def dummy_test(A, B):
         Wrapped_coord = sw.matlab_SurfStatInd2Coord(A, B)
 
     except:
-        pytest.fail("ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS...")
-
+        pytest.skip("Original MATLAB code does not work with these inputs.")
+        
     Python_coord = py_SurfStatInd2Coord(A, B)
 
     # compare matlab-python outputs

--- a/surfstat/tests/test_SurfStatLinMod.py
+++ b/surfstat/tests/test_SurfStatLinMod.py
@@ -4,6 +4,7 @@ from SurfStatLinMod import *
 import surfstat_wrap as sw
 import numpy as np
 from term import Term
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -25,7 +26,7 @@ def dummy_test(A, B, surf):
         Wrapped_SurfStatLinMod = sw.matlab_SurfStatLinMod(Amat, Bmat, surf)
 
     except:
-        pytest.fail("ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS...")
+        pytest.skip("Original MATLAB code does not work with these inputs.")
 	
     # run python functions
     Python_SurfStatLinMod = py_SurfStatLinMod(A, B, surf)

--- a/surfstat/tests/test_SurfStatNorm.py
+++ b/surfstat/tests/test_SurfStatNorm.py
@@ -3,6 +3,7 @@ sys.path.append("python")
 from SurfStatNorm import *
 import surfstat_wrap as sw
 import numpy as np
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -12,7 +13,7 @@ def dummy_test(Y, mask, subdiv):
         # wrap matlab functions
         Wrapped_Y, Wrapped_Yav = sw.matlab_SurfStatNorm(Y, mask, subdiv)
     except:
-        pytest.fail("ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS...")
+        pytest.skip("Original MATLAB code does not work with these inputs.")
 
     Python_Y, Python_Yav = py_SurfStatNorm(Y, mask, subdiv)
 

--- a/surfstat/tests/test_SurfStatSmooth.py
+++ b/surfstat/tests/test_SurfStatSmooth.py
@@ -3,6 +3,7 @@ sys.path.append("python")
 from SurfStatSmooth import *
 import surfstat_wrap as sw
 import numpy as np
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -12,7 +13,7 @@ def dummy_test(Y, surf, FWHM):
         # wrap matlab functions
         Wrapped_Y = sw.matlab_SurfStatSmooth(Y, surf, FWHM)
     except:
-        pytest.fail("ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS...")
+        pytest.skip("Original MATLAB code does not work with these inputs.")
 
     # run matlab equivalent
     Python_Y = py_SurfStatSmooth(Y, surf, FWHM)

--- a/surfstat/tests/test_SurfStatStand.py
+++ b/surfstat/tests/test_SurfStatStand.py
@@ -3,6 +3,7 @@ sys.path.append("python")
 from SurfStatStand import *
 import surfstat_wrap as sw
 import numpy as np
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -13,8 +14,8 @@ def dummy_test(Y, mask, subtractordivide):
 		Wrapped_Y, Wrapped_Ym = sw.matlab_SurfStatStand(Y, mask, subtractordivide) 
 
 	except:
-		print >> sys.stderr, "ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS..."
-		sys.exit(1)
+		pytest.skip("Original MATLAB code does not work with these inputs.")
+		
 
 	# python function
 	Python_Y, Python_Ym = py_SurfStatStand(Y, mask, subtractordivide)

--- a/surfstat/tests/test_SurfStatT.py
+++ b/surfstat/tests/test_SurfStatT.py
@@ -4,6 +4,7 @@ from SurfStatT import *
 import surfstat_wrap as sw
 import numpy as np
 import sys
+import pytest
 
 sw.matlab_init_surfstat()
 
@@ -14,11 +15,9 @@ def dummy_test(slm, contrast):
 		Wrapped_slm = sw.matlab_SurfStatT(slm, contrast)
 		
 	except:
-		print >> sys.stderr, "ORIGINAL MATLAB CODE DOES NOT WORK WITH THESE INPUTS..."
-		sys.exit(1)
-	
+		pytest.skip("Original MATLAB code does not work with these inputs.")
+		
 	# run python functions
-
 	Python_slm = py_SurfStatT(slm, contrast)
 	
 	testout_SurfStatT = []

--- a/surfstat/tests/test_statthreshold.py
+++ b/surfstat/tests/test_statthreshold.py
@@ -14,6 +14,7 @@ import math
 import itertools
 import pdb
 import pytest
+from scipy.io import loadmat
 
 def var2mat(var):
     # Brings the input variables to matlab format.
@@ -25,8 +26,9 @@ def var2mat(var):
         var = [var]
     return matlab.double(var)
 
+
 def dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-        cluster_threshold, p_val_extent, nconj, nvar):
+        cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint):
 
     try:
         # run matlab functions (wrapping...)    
@@ -43,7 +45,7 @@ def dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak,
                         var2mat(nvar), 
                         var2mat(None), 
                         var2mat(None), 
-                        var2mat(0),
+                        var2mat(nprint),
                         nargout=6)
         mat_output = [peak_threshold_mat, 
                         extent_threshold_mat, 
@@ -65,8 +67,11 @@ def dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak,
                     cluster_threshold, 
                     p_val_extent, 
                     nconj, 
-                    nvar, 
-                    nprint=0)
+                    nvar,
+                    None, 
+                    None, 
+                    nprint)
+                    
     py_output = [peak_threshold_py, 
                     extent_threshold_py, 
                     peak_threshold_1_py, 
@@ -111,9 +116,12 @@ def test_1():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 #Test 2 --> search_volume is a list  (rest is default-values)
 def test_2():
@@ -130,9 +138,12 @@ def test_2():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 
 #Test 3 --> search_volume is a 1D numpy array (rest is default-values)
@@ -150,9 +161,12 @@ def test_3():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 
 #Test 4 --> search_volume is a 2D numpy array (rest is default-values)
@@ -169,9 +183,12 @@ def test_4():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 
 #Test 5 --> search_volume a float, num_voxels: an int
@@ -185,9 +202,12 @@ def test_5():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 #Test 6 --> search_volume 2D numpy array, num_voxels: a list 
 def test_6():
@@ -204,9 +224,12 @@ def test_6():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 #Test 7 --> search_volume 2D array, num_voxels: 2D array of shape (k,1),
 # fwhm float, df: int
@@ -224,9 +247,12 @@ def test_7():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 #Test 8 --> search_volume 2D array, num_voxels: 2D array of shape (k,1),
 # fwhm float, df: math.inf
@@ -246,9 +272,12 @@ def test_8():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 #Test 9 --> search_volume float, num_voxels: 2D array of shape (1,k),
 # fwhm float, df: int, p_val_peak: float
@@ -268,9 +297,12 @@ def test_9():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 #Test 10 --> search_volume float, num_voxels: 2D array of shape (1,k),
 # fwhm float, df: int, p_val_peak: list
@@ -290,9 +322,12 @@ def test_10():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 #Test 11 --> search_volume float, num_voxels: 2D array of shape (1,k),
 # fwhm float, df: int, p_val_peak: 1D array
@@ -311,9 +346,12 @@ def test_11():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 
 # Test 12 --> search_volume float, num_voxels: 2D array of shape (1,k),
@@ -333,9 +371,12 @@ def test_12():
     p_val_extent      = 0.05
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 # Test 13 --> search_volume float, num_voxels: int,
 # fwhm float, df: int, p_val_peak: 1D array, cluster_threshold: float,
@@ -354,10 +395,12 @@ def test_13():
     p_val_extent      = np.random.rand(k)
     nconj             = 0.5
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
-
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 # Test 14 --> search_volume float, num_voxels: int,
 # fwhm float, df: int, p_val_peak: 1D array, cluster_threshold: float,
@@ -377,9 +420,12 @@ def test_14():
     p_val_extent      = np.random.rand(k,1)
     nconj             = l
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
 # Test 15 --> 
 def test_15():
@@ -392,29 +438,38 @@ def test_15():
     p_val_extent      = 0.01
     nconj             = 0.02
     nvar              = [1,1]
+    EC_file           = None
+    expr              = None 
+    nprint            = 0
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
 
-# Test 16 -->
+# buggy case 
 def test_16():
-    rng = np.random.default_rng()
-
-    m = np.random.randint(1,10)
-    n = np.random.randint(1,10)
-    k = np.random.randint(1,10)
-
-    rng = np.random.default_rng()
-
-    search_volume     = np.random.uniform(0,100)
-    num_voxels        = rng.integers(1,10, size=(k))
-    fwhm              = np.random.uniform(0,10)
-    df                = [m,n]
-    p_val_peak        = 0.05
+    #slmdata = loadmat('./tests/data/someresels.mat')
+    resels = np.array([[4.00000000e+00,  np.NaN, 6.59030991e+03]])
+    N = 64984
+    df = np.array([[1111, 0], [1111, 1111]])
+    
+    # this is from some real test data
+    search_volume     = resels
+    num_voxels        = N
+    fwhm              = 1
+    df                = df 
+    p_val_peak        = np.array([0.5, 1])
     cluster_threshold = 0.001
     p_val_extent      = 0.05
-    nconj             = 0.5
+    nconj             = 1
     nvar              = 1
+    EC_file           = None
+    expr              = None 
+    nprint            = 1
 
     dummy_test(eng, search_volume, num_voxels, fwhm, df, p_val_peak, 
-            cluster_threshold, p_val_extent, nconj, nvar)
+            cluster_threshold, p_val_extent, nconj, nvar, EC_file, expr, nprint)
+
+
+
+
+


### PR DESCRIPTION
I came across a bug in `stat_threshold.py` while merging it in `SurfStatP.py` .
Basically, if there are two np arrays, one having NaN values, then np.minimum() would take the NaN as outcome. This is now fixed with np.nanmin(), it ignores the NaN values.