### PR TITLE
Stat px

### DIFF
--- a/surfstat/python/SurfStatP.py
+++ b/surfstat/python/SurfStatP.py
@@ -8,6 +8,7 @@ from scipy.interpolate import interp1d
 from scipy.io import loadmat
 from stat_threshold import stat_threshold
 from SurfStatPeakClus import py_SurfStatPeakClus
+from SurfStatResels import py_SurfStatResels
 import copy
 
 
@@ -130,15 +131,7 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
     else:
         thresh = clusthresh
 
-    # NEED TO BE CALLED FROM PYTHON SURFSTATRESELS
-    mat_output = sw.matlab_SurfStatResels(slm, mask)
-    mat_output = mat_output.tolist()
-    if isinstance(mat_output,float):
-        mat_output = [mat_output]
-    if len(mat_output) == 3:
-        resels = np.array(mat_output[0])
-        reselspvert = np.array(mat_output[1])
-        edg = np.array(mat_output[2])
+    resels, reselspvert, edg = py_SurfStatResels(slm, mask.flatten())
 
     N = mask.sum()
     

--- a/surfstat/python/SurfStatP.py
+++ b/surfstat/python/SurfStatP.py
@@ -1,30 +1,11 @@
 import sys
-sys.path.append("python")
-sys.path.append("../surfstat")
-import surfstat_wrap as sw
-import matlab.engine
 import numpy as np
+import copy
 from scipy.interpolate import interp1d
-from scipy.io import loadmat
+sys.path.append("python")
 from stat_threshold import stat_threshold
 from SurfStatPeakClus import py_SurfStatPeakClus
 from SurfStatResels import py_SurfStatResels
-import copy
-
-
-# WRAPPING FUNCTIONS NEED TO BE REMOVED LATER...
-sw.matlab_init_surfstat()
-eng = matlab.engine.start_matlab()
-eng.addpath('matlab/')
-def var2mat(var):
-    # Brings the input variables to matlab format.
-    if isinstance(var, np.ndarray):
-        var = var.tolist()
-    elif var == None:
-        var = []
-    if not isinstance(var,list) and not isinstance(var, np.ndarray):
-        var = [var]
-    return matlab.double(var)
 
 def py_SurfStatP(slm, mask=None, clusthresh=0.001):
     """Corrected P-values for vertices and clusters.

--- a/surfstat/python/SurfStatP.py
+++ b/surfstat/python/SurfStatP.py
@@ -87,12 +87,8 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
     if v == 1:
         varA = varA = np.concatenate((np.array([10]), slm['t'][0]))
         pval = {}
-        pval['P'] = stat_threshold(search_volume = 0, num_voxels = 1, 
-                                   fwhm = 0, df = df, p_val_peak = varA,
-                                   cluster_threshold = 0.001, 
-                                   p_val_extent = 0.05, nconj = 1,
-                                   nvar = float(slm['k']), EC_file = None,
-                                   expr = None, nprint = 0)[0]
+        pval['P'] = stat_threshold(df = df, p_val_peak = varA,
+                                   nvar = float(slm['k']), nprint = 0)[0]
         pval['P'] = pval['P'][1]
         peak = []
         clus = []
@@ -101,12 +97,8 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
         return pval, peak, clus, clusid
     
     if clusthresh < 1:
-        thresh = stat_threshold(search_volume = 0, num_voxels = 1, 
-                                fwhm = 0, df = df, p_val_peak = clusthresh,
-                                cluster_threshold = 0.001, p_val_extent = 0.05, 
-                                nconj = 1, nvar = float(slm['k']),
-                                EC_file = None, expr = None, 
-                                nprint = 0)[0]
+        thresh = stat_threshold(df = df, p_val_peak = clusthresh,
+                                nvar = float(slm['k']), nprint = 0)[0]
         thresh = float(thresh[0])
     else:
         thresh = clusthresh
@@ -120,10 +112,7 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
         pval['P'] = stat_threshold(search_volume = resels, num_voxels = N,
                                    fwhm = 1, df = df,
                                    p_val_peak = varA.flatten(), 
-                                   cluster_threshold = 0.001, 
-                                   p_val_extent = 0.05,  nconj = 1,
-                                   nvar = float(slm['k']), EC_file = None, 
-                                   expr = None, nprint = 0)[0]
+                                   nvar = float(slm['k']), nprint = 0)[0]
         pval['P'] = pval['P'][1:v+1]
         peak = []
         clus = []
@@ -134,15 +123,13 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
         varA = np.concatenate((np.array([[10]]), peak['t'].T , slm['t']),
                               axis=1)
         varB = np.concatenate((np.array([[10]]), clus['resels']))
-        pp, clpval, a,b,c,d = stat_threshold(search_volume = resels, 
-                                             num_voxels = N, fwhm = 1,
-                                             df = df, 
-                                             p_val_peak = varA.flatten(),
-                                             cluster_threshold = thresh,
-                                             p_val_extent = varB,
-                                             nconj = 1, nvar = float(slm['k']),
-                                             EC_file = None, 
-                                             expr = None, nprint = 0)
+        pp, clpval, _, _, _, _, = stat_threshold(search_volume = resels,
+                                                 num_voxels = N, fwhm = 1,
+                                                 df = df,
+                                                 p_val_peak = varA.flatten(),
+                                                 cluster_threshold = thresh,
+                                                 p_val_extent = varB,
+                                                 nvar = float(slm['k']), nprint = 0)
         lenPP = len(pp[1:len(peak['t'])+1])
         peak['P'] = pp[1:len(peak['t'])+1].reshape(lenPP, 1)
         pval = {}
@@ -159,9 +146,7 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
             
     tlim = stat_threshold(search_volume = resels, num_voxels = N, fwhm = 1,
                           df = df, p_val_peak = np.array([0.5, 1]),
-                          cluster_threshold=0.001, p_val_extent=0.05, nconj=1, 
-                          nvar = float(slm['k']), EC_file = None, expr = None, 
-                          nprint = 0)[0]
+                          nvar = float(slm['k']), nprint = 0)[0]
     tlim = tlim[1]
     pval['P'] = pval['P'] * (slm['t'][0,:] > tlim) + (slm['t'][0,:] <= tlim)
     pval['mask'] = mask

--- a/surfstat/python/SurfStatP.py
+++ b/surfstat/python/SurfStatP.py
@@ -1,4 +1,195 @@
+import sys
+sys.path.append("python")
+sys.path.append("../surfstat")
+import surfstat_wrap as sw
+import matlab.engine
 import numpy as np
+from scipy.interpolate import interp1d
+from scipy.io import loadmat
+from stat_threshold import stat_threshold
+from SurfStatPeakClus import py_SurfStatPeakClus
+import copy
 
-def py_SurfStatP(slm, mask, clusthresh):
-    sys.exit("Function py_SurfStatP is not implemented yet")
+
+# WRAPPING FUNCTIONS NEED TO BE REMOVED LATER...
+sw.matlab_init_surfstat()
+eng = matlab.engine.start_matlab()
+eng.addpath('matlab/')
+def var2mat(var):
+    # Brings the input variables to matlab format.
+    if isinstance(var, np.ndarray):
+        var = var.tolist()
+    elif var == None:
+        var = []
+    if not isinstance(var,list) and not isinstance(var, np.ndarray):
+        var = [var]
+    return matlab.double(var)
+
+def py_SurfStatP(slm, mask=None, clusthresh=0.001):
+    """Corrected P-values for vertices and clusters.
+
+    Parameters
+    ----------
+    slm : a dictionary with keys 't', 'df', 'k', 'resl', 'tri' (or 'lat'), 
+        optional key 'dfs'.
+        slm['t'] : 2D numpy array of shape (l,v).
+            v is the number of vertices, slm['t'][0,:] is the test statistic, 
+            rest of the rows are used to calculate cluster resels if 
+            slm['k']>1. See SurfStatF for the precise definition of extra rows.
+        surf['df'] : 2D numpy array of shape (1,1), dtype=int.
+            Degrees of freedom.
+        surf['k'] : an int.
+            Number of variates.
+        surf['resl'] : 2D numpy array of shape (e,k).
+            Sum over observations of squares of differences of normalized 
+            residuals along each edge.
+        surf['tri'] : 2D numpy array of shape (3,t), dtype=int.
+            Triangle indices.
+        or,
+        surf['lat'] : 3D numpy array of shape (nx,ny,nz), 1's and 0's.
+            In fact, [nx,ny,nz] = size(volume).
+        surf['dfs'] : 2D numpy array of shape (1,v), dtype=int.
+            Optional effective degrees of freedom.
+    mask : 2D numpy array of shape (1,v), dtype=bool.
+        1=inside, 0=outside, v= number of vertices. By default: np.ones((1,v), 
+        dtype=bool).
+    clusthresh: a float.
+        P-value threshold or statistic threshold for defining clusters.
+        By default: 0.001.
+    
+    Returns
+    -------
+    pval : a dictionary with keys 'P', 'C', 'mask'.
+        pval['P'] : 2D numpy array of shape (1,v).
+            Corrected P-values for vertices.
+        pval['C'] : 2D numpy array of shape (1,v).
+            Corrected P-values for clusters.
+        pval['mask'] : copy of input mask.
+    peak : a dictionary with keys 't', 'vertid', 'clusid', 'P'.
+        peak['t'] : 2D numpy array of shape (np,1). 
+            Peaks (local maxima).
+        peak['vertid'] : 2D numpy array of shape (np,1). 
+            Vertex.
+        peak['clusid'] : 2D numpy array of shape (np,1). 
+            Cluster id numbers.
+        peak['P'] : 2D numpy array of shape (np,1). 
+            Corrected P-values for the peak.
+    clus : a dictionary with keys 'clusid', 'nverts', 'resels', 'P.'
+        clus['clusid'] : 2D numpy array of shape (nc,1). 
+            Cluster id numbers
+        clus['nverts'] : 2D numpy array of shape (nc,1). 
+            Number of vertices in cluster.
+        clus['resels'] : 2D numpy array of shape (nc,1). 
+            Resels in the cluster.
+        clus['P'] : 2D numpy array of shape (nc,1). 
+            Corrected P-values for the cluster.
+    clusid : 2D numpy array of shape (1,v). 
+        Cluster id's for each vertex.
+
+    Reference: Worsley, K.J., Andermann, M., Koulis, T., MacDonald, D.
+    & Evans, A.C. (1999). Detecting changes in nonisotropic images.
+    Human Brain Mapping, 8:98-101.
+    """
+    l, v =np.shape(slm['t'])
+
+    if mask is None:
+        mask = np.ones((1,v), dtype=bool)
+
+    df = np.zeros((2,2))
+    ndf = len(slm['df'])
+    df[0, 0:ndf] = slm['df']
+    df[1, 0:2] = slm['df'][ndf-1]
+    
+    if 'dfs' in slm.keys():
+        df[0, ndf-1] = slm['dfs'][mask > 0].mean()
+    
+    if v == 1:
+        varA = varA = np.concatenate((np.array([10]), slm['t'][0]))
+        pval = {}
+        pval['P'] = stat_threshold(search_volume = 0, num_voxels = 1, 
+                                   fwhm = 0, df = df, p_val_peak = varA,
+                                   cluster_threshold = 0.001, 
+                                   p_val_extent = 0.05, nconj = 1,
+                                   nvar = float(slm['k']), EC_file = None,
+                                   expr = None, nprint = 0)[0]
+        pval['P'] = pval['P'][1]
+        peak = []
+        clus = []
+        clusid = []
+        # only a single p-value is returned, and function is stopped.
+        return pval, peak, clus, clusid
+    
+    if clusthresh < 1:
+        thresh = stat_threshold(search_volume = 0, num_voxels = 1, 
+                                fwhm = 0, df = df, p_val_peak = clusthresh,
+                                cluster_threshold = 0.001, p_val_extent = 0.05, 
+                                nconj = 1, nvar = float(slm['k']),
+                                EC_file = None, expr = None, 
+                                nprint = 0)[0]
+        thresh = float(thresh[0])
+    else:
+        thresh = clusthresh
+
+    # NEED TO BE CALLED FROM PYTHON SURFSTATRESELS
+    resels, reselspvert, edg = sw.matlab_SurfStatResels(slm, mask)
+    N = mask.sum()
+    
+    if np.max(slm['t'][0, mask.flatten()]) < thresh:
+        pval = {}
+        varA = np.concatenate((np.array([[10]]), slm['t']), axis=1)
+        pval['P'] = stat_threshold(search_volume = resels, num_voxels = N,
+                                   fwhm = 1, df = df,
+                                   p_val_peak = varA.flatten(), 
+                                   cluster_threshold = 0.001, 
+                                   p_val_extent = 0.05,  nconj = 1,
+                                   nvar = float(slm['k']), EC_file = None, 
+                                   expr = None, nprint = 0)[0]
+        pval['P'] = pval['P'][1:v+1]
+        peak = []
+        clus = []
+        clusid = []
+    else:
+        # py_SurfStatPeakClus changes the slm after operation, so deepcopy..
+        slm_tmp = copy.deepcopy(slm)
+    
+        peak, clus, clusid = py_SurfStatPeakClus(slm_tmp, mask, thresh,
+                                                 reselspvert, edg.astype(int))
+        
+        slm['t'] = slm['t'].reshape(1, slm['t'].size)
+        varA = np.concatenate((np.array([[10]]), peak['t'].T , slm['t']),
+                              axis=1)
+        varB = np.concatenate((np.array([[10]]), clus['resels']))
+        pp, clpval, a,b,c,d = stat_threshold(search_volume = resels, 
+                                             num_voxels = N, fwhm = 1,
+                                             df = df, 
+                                             p_val_peak = varA.flatten(),
+                                             cluster_threshold = thresh,
+                                             p_val_extent = varB,
+                                             nconj = 1, nvar = float(slm['k']),
+                                             EC_file = None, 
+                                             expr = None, nprint = 0)
+        lenPP = len(pp[1:len(peak['t'])+1])
+        peak['P'] = pp[1:len(peak['t'])+1].reshape(lenPP, 1)
+        pval = {}
+        pval['P'] = pp[len(peak['t']) + np.arange(1,v+1)]
+        
+        if slm['k'] > 1:
+            print('NOT YET IMPLEMENTED')
+            sys.exit()
+
+        clus['P'] = clpval[1:len(clpval)]
+        x = np.concatenate((np.array([[0]]), clus['clusid']), axis=0)
+        y = np.concatenate((np.array([[1]]), clus['P']), axis=0)
+        pval['C'] = interp1d(x.flatten(),y.flatten())(clusid)
+            
+    tlim = stat_threshold(search_volume = resels, num_voxels = N, fwhm = 1,
+                          df = df, p_val_peak = np.array([0.5, 1]),
+                          cluster_threshold=0.001, p_val_extent=0.05, nconj=1, 
+                          nvar = float(slm['k']), EC_file = None, expr = None, 
+                          nprint = 0)[0]
+    tlim = tlim[1]
+    pval['P'] = pval['P'] * (slm['t'][0,:] > tlim) + (slm['t'][0,:] <= tlim)
+    pval['mask'] = mask
+
+    return pval, peak, clus, clusid
+

--- a/surfstat/python/SurfStatP.py
+++ b/surfstat/python/SurfStatP.py
@@ -131,7 +131,15 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
         thresh = clusthresh
 
     # NEED TO BE CALLED FROM PYTHON SURFSTATRESELS
-    resels, reselspvert, edg = sw.matlab_SurfStatResels(slm, mask)
+    mat_output = sw.matlab_SurfStatResels(slm, mask)
+    mat_output = mat_output.tolist()
+    if isinstance(mat_output,float):
+        mat_output = [mat_output]
+    if len(mat_output) == 3:
+        resels = np.array(mat_output[0])
+        reselspvert = np.array(mat_output[1])
+        edg = np.array(mat_output[2])
+
     N = mask.sum()
     
     if np.max(slm['t'][0, mask.flatten()]) < thresh:

--- a/surfstat/python/SurfStatP.py
+++ b/surfstat/python/SurfStatP.py
@@ -1,6 +1,5 @@
 import sys
 import numpy as np
-import copy
 from scipy.interpolate import interp1d
 sys.path.append("python")
 from stat_threshold import stat_threshold
@@ -113,7 +112,6 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
         thresh = clusthresh
 
     resels, reselspvert, edg = py_SurfStatResels(slm, mask.flatten())
-
     N = mask.sum()
     
     if np.max(slm['t'][0, mask.flatten()]) < thresh:
@@ -131,12 +129,7 @@ def py_SurfStatP(slm, mask=None, clusthresh=0.001):
         clus = []
         clusid = []
     else:
-        # py_SurfStatPeakClus changes the slm after operation, so deepcopy..
-        slm_tmp = copy.deepcopy(slm)
-    
-        peak, clus, clusid = py_SurfStatPeakClus(slm_tmp, mask, thresh,
-                                                 reselspvert, edg.astype(int))
-        
+        peak, clus, clusid = py_SurfStatPeakClus(slm, mask, thresh,reselspvert, edg)
         slm['t'] = slm['t'].reshape(1, slm['t'].size)
         varA = np.concatenate((np.array([[10]]), peak['t'].T , slm['t']),
                               axis=1)

--- a/surfstat/python/SurfStatResels.py
+++ b/surfstat/python/SurfStatResels.py
@@ -397,6 +397,6 @@ def py_SurfStatResels(slm, mask=None):
     D = lkcs.shape[1]-1
     resels = lkcs / np.sqrt(4*np.log(2))**np.arange(0,D+1)
     # back to matlab indexing by +1, otherwise tests will fail
-    edg = edg + 1
+    edg = (edg + 1).astype(int)
 
     return resels, reselspvert, edg

--- a/surfstat/python/SurfStatResels.py
+++ b/surfstat/python/SurfStatResels.py
@@ -31,7 +31,7 @@ def py_SurfStatResels(slm, mask=None):
     resels : a 2D numpy array of shape (1, (D+1)).
         Array of 0,...,D dimensional resels of the mask, EC of the mask 
         if slm['resl'] is not given.
-    reselspvert : a 1D numpy array of shape (v,).
+    reselspvert : a 2D numpy array of shape (1,v).
         Array of D-dimensional resels per mask vertex.
     edg : a 2D numpy array of shape (e, 2).
         Array of edge indices.
@@ -99,6 +99,8 @@ def py_SurfStatResels(slm, mask=None):
                         np.bincount(tri[masktri,j], weights=r2, minlength=v)
             D = 2
             reselspvert = reselspvert.T / (D+1) / np.sqrt(4*np.log(2)) ** D
+            # from shape (v,) to (1,v)
+            reselspvert = np.reshape(reselspvert, (1,-1))
         else:
             reselspvert = None
         
@@ -382,6 +384,8 @@ def py_SurfStatResels(slm, mask=None):
         # ignore it as no equivalent exists in Python - RV. 
         D = 2 + (K>1)
         reselspvert = reselspvert.T / (D+1) / np.sqrt(4*np.log(2)) ** D
+        # from shape (v,) to (1,v)
+        reselspvert = np.reshape(reselspvert, (1,-1))
     
     ## Compute resels - RV
     D1 = lkc.shape[0]-1
@@ -392,5 +396,7 @@ def py_SurfStatResels(slm, mask=None):
     lkcs = np.atleast_2d(lkcs)
     D = lkcs.shape[1]-1
     resels = lkcs / np.sqrt(4*np.log(2))**np.arange(0,D+1)
+    # back to matlab indexing by +1, otherwise tests will fail
+    edg = edg + 1
 
     return resels, reselspvert, edg

--- a/surfstat/surfstat_wrap.py
+++ b/surfstat/surfstat_wrap.py
@@ -240,9 +240,39 @@ def matlab_SurfStatNorm(Y, mask=None, subdiv='s'):
 
 
 # ==> SurfStatP.m <==
-# TODO original matlab signature was SurfStatP(slm, mask, clusthresh):
-def matlab_SurfStatP(results):
-    return surfstat_eng.SurfStatP(results)
+def matlab_SurfStatP(slm, mask=None, clusthresh=0.001):
+
+    slm_mat = slm.copy()
+    for key in slm_mat.keys():
+        if isinstance(slm_mat[key], np.ndarray):
+            slm_mat[key] = matlab.double(slm_mat[key].tolist()) 
+        else:
+            slm_mat[key] = surfstat_eng.double(slm_mat[key])
+
+    if mask is None:
+        mask_mat = matlab.double([])
+        pval, peak, clus, clusid = surfstat_eng.SurfStatP(slm_mat, mask_mat, 
+                                                          clusthresh, nargout=4) 
+    else:
+        mask_mat = matlab.double(np.array(mask, dtype=int).tolist())
+        mask_mat = matlab.logical(mask_mat)    
+        pval, peak, clus, clusid = surfstat_eng.SurfStatP(slm_mat, mask_mat, 
+                                                          clusthresh, nargout=4)
+    for key in pval:
+        pval[key] = np.array(pval[key])
+    for key in peak:
+        peak[key] = np.array(peak[key])
+    for key in clus:
+        clus[key] = np.array(clus[key])
+    clusid = np.array(clusid)
+
+    return pval, peak, clus, clusid
+
+
+
+
+
+
 
 # ==> SurfStatPCA.m <==
 def matlab_SurfStatPCA(Y, mask, X, k):

--- a/surfstat/surfstat_wrap.py
+++ b/surfstat/surfstat_wrap.py
@@ -402,10 +402,10 @@ def matlab_SurfStatResels(slm, mask=None):
     
     slm_mat = slm.copy()
     for key in slm_mat.keys():
-        if np.ndim(slm_mat[key]) == 0:
-            slm_mat[key] = surfstat_eng.double(slm_mat[key].item())
-        else:
+        if isinstance(slm_mat[key], np.ndarray):
             slm_mat[key] = matlab.double(slm_mat[key].tolist())
+        else:
+            slm_mat[key] = surfstat_eng.double(slm_mat[key])
 
     # MATLAB errors if 'resl' is not provided and more than 1 output argument is requested.
     if 'resl' in slm:

--- a/surfstat/tests/test_SurfStatP.py
+++ b/surfstat/tests/test_SurfStatP.py
@@ -6,6 +6,8 @@ from scipy.io import loadmat
 import numpy as np
 import pytest
 
+sw.matlab_init_surfstat()
+
 def dummy_test(slm, mask=None, clusthresh=0.001):
 
     try:

--- a/surfstat/tests/test_SurfStatP.py
+++ b/surfstat/tests/test_SurfStatP.py
@@ -54,3 +54,217 @@ def test_1():
     slm['tri'] = slmdata['slm']['tri'][0,0]
     slm['dfs'] =  np.array([[np.random.randint(1,10)]])
     dummy_test(slm)
+
+def test_2():
+    # special case, v=1, l>1
+    l = np.random.randint(1,10000)
+    v = int(1)
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = np.random.rand(l,v)
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    slm['dfs'] =  np.array([[np.random.randint(1,10)]])
+    py_SurfStatP(slm)
+
+def test_3():
+    #special case, v=1, l>1, other input more randomized
+    l = np.random.randint(1,10000)
+    v = int(1)
+    e = np.random.randint(1,10)
+    k = 1
+    d = np.random.randint(1111,2000)
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = np.random.rand(l,v)
+    slm['df'] = np.array([[d]])
+    slm['k'] = k
+    slm['resl'] = np.random.rand(e,k)
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    slm['dfs'] =  np.array([[np.random.randint(1,10)]])
+    dummy_test(slm)
+
+def test_4():
+    # v >1 and clusthresh < 1 (default clusthresh)
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = slmdata['slm']['t'][0,0]
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    dummy_test(slm,  mask=None, clusthresh=0.001)
+
+def test_5():
+    # v >1 and clusthresh < 1 (default clusthresh)
+    l = 1
+    v = 64984
+    e = 194940
+    k = 1
+    d = 1111
+    slm = {}
+    slm['t'] = np.random.uniform(-5,5, (l,v))
+    slm['df'] = np.array([[d]])
+    slm['k'] = k
+    slm['resl'] = np.random.rand(e,k)
+    slm['tri'] = np.random.randint(low=1, high=64984+1, size=(129960, 3))
+    dummy_test(slm,  mask=None, clusthresh=0.001)
+    
+def test_6():
+    # v >1 and clusthresh < 1 (default clusthresh)
+    l = 1
+    v = 64984
+    e = 194940
+    k = 1
+    d = np.random.randint(1111, 2000)
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = np.random.uniform(-5,5, (l,v))
+    slm['df'] = np.array([[d]])
+    slm['k'] = k
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    dummy_test(slm,  mask=None, clusthresh=0.001)
+    
+def test_7():
+    # special case np.max(slm['t'][0, mask.flatten()]) < thresh
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = np.random.uniform(low=-4, high=0, size=(1,64984))
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    dummy_test(slm)
+    
+def test_8():
+    # special case np.max(slm['t'][0, mask.flatten()]) < thresh
+    # make slm['df'] a random integer
+    d = np.random.randint(1111, 2000)
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = np.random.uniform(low=-4, high=0, size=(1,64984))
+    slm['df'] = np.array([[d]])
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    dummy_test(slm)
+
+def test_9():
+    # special case case np.max(slm['t'][0, mask.flatten()]) > thresh
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = np.random.uniform(low=0, high=4, size=(1,64984))
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    dummy_test(slm)
+
+def test_10():
+    # data from Sofie
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = slmdata['slm']['t'][0,0]
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    dummy_test(slm)
+
+def test_11():
+    # data from Sofie + a random mask
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = slmdata['slm']['t'][0,0]
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+
+    v = np.shape(slmdata['slm']['t'][0,0])[1]
+    Amask = np.random.choice([0, 1], size=(1,v))
+    Amask = np.array(Amask, dtype=bool)
+
+    dummy_test(slm, mask=Amask)
+
+def test_12():
+    # data from Sofie + clusthresh is a random value
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+
+    slm = {}
+
+    slm['t'] = slmdata['slm']['t'][0,0]
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+
+    Amask = np.ones((1, slm['t'].shape[1]))
+    Amask = np.array(Amask, dtype=bool)
+    Aclusthresh = 0.3
+    dummy_test(slm, Amask, Aclusthresh)
+
+def test_13():
+    # randomize Sofie's data a little bit
+    v = int(64984)
+    y = int(194940)
+
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+
+    slm = {}
+
+    slm['t'] = np.random.rand(1,v)
+    slm['df'] = np.array([1111])
+    slm['k'] = 1
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+
+    dummy_test(slm)
+
+def test_14():
+    # data from Sofie, slm['t'] is array of shape (1,1)
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+
+    slm = {}
+
+    slm['t'] = np.array([[-0.1718374541922737]])
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = 1
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+
+    dummy_test(slm)
+
+def test_15():
+    # data from Sofie + add a random slm['dfs']
+    v = int(64984)
+
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+
+    slm = {}
+
+    slm['t'] = slmdata['slm']['t'][0,0]
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    slm['dfs'] = np.random.randint(1,10, (1,v))
+    
+    dummy_test(slm)
+

--- a/surfstat/tests/test_SurfStatP.py
+++ b/surfstat/tests/test_SurfStatP.py
@@ -270,3 +270,27 @@ def test_15():
     
     dummy_test(slm)
 
+# BUG case
+def test_16():
+    # data from Reinder, slm.k = 3    
+
+    slmfile = './tests/data/slmk3.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = slmdata['slm']['t'][0,0]
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+
+
+    dummy_test(slm)
+
+
+
+
+
+
+
+
+

--- a/surfstat/tests/test_SurfStatP.py
+++ b/surfstat/tests/test_SurfStatP.py
@@ -1,0 +1,56 @@
+import sys
+sys.path.append("python")
+from SurfStatP import *
+import surfstat_wrap as sw
+from scipy.io import loadmat
+import numpy as np
+import pytest
+
+def dummy_test(slm, mask=None, clusthresh=0.001):
+
+    try:
+        # wrap matlab functions
+        M_pval, M_peak, M_clus, M_clusid = sw.matlab_SurfStatP(slm, 
+                                                               mask, 
+                                                               clusthresh)
+
+    except:
+        pytest.skip("Original MATLAB code does not work with these inputs.")
+
+    # run python equivalent
+    PY_pval, PY_peak, PY_clus, PY_clusid = py_SurfStatP(slm, 
+                                                        mask,
+                                                        clusthresh)
+
+    # compare matlab-python outputs
+    testout_SurfStatP = []
+
+    for key in M_pval:
+        testout_SurfStatP.append(np.allclose(M_pval[key], PY_pval[key], 
+                                      rtol=1e-05, equal_nan=True))
+    for key in M_peak:
+        testout_SurfStatP.append(np.allclose(M_peak[key], PY_peak[key], 
+                                      rtol=1e-05, equal_nan=True))
+    for key in M_clus:
+        testout_SurfStatP.append(np.allclose(M_clus[key], PY_clus[key], 
+                                      rtol=1e-05, equal_nan=True))
+    testout_SurfStatP.append(np.allclose(M_clusid, PY_clusid, 
+                              rtol=1e-05, equal_nan=True))
+
+
+    assert (all(flag == True for (flag) in testout_SurfStatP))
+
+def test_1():
+    # special case, v =1, l=1
+    l = int(1)
+    v = int(1)
+    slmfile = './tests/data/slm.mat'
+    slmdata = loadmat(slmfile)
+    slm = {}
+    slm['t'] = np.random.rand(l,v)
+    slm['df'] = slmdata['slm']['df'][0,0]
+    slm['k'] = slmdata['slm']['k'][0,0]
+    slm['resl'] = slmdata['slm']['resl'][0,0]
+    slm['tri'] = slmdata['slm']['tri'][0,0]
+    slm['dfs'] =  np.array([[np.random.randint(1,10)]])
+    dummy_test(slm)

--- a/surfstat/tests/test_SurfStatResels.py
+++ b/surfstat/tests/test_SurfStatResels.py
@@ -8,7 +8,6 @@ import math
 import itertools
 import pytest
 from scipy.io import loadmat
-import pdb 
 
 sw.matlab_init_surfstat()
 
@@ -35,7 +34,7 @@ def dummy_test(slm, mask=None):
     else:
         py_output = [resels_py,
                      reselspvert_py,
-                     edg_py+1]
+                     edg_py]
     
     # compare matlab-python outputs
     test_out = [] 
@@ -44,9 +43,7 @@ def dummy_test(slm, mask=None):
                             np.squeeze(np.asarray(mat)),
                             rtol=1e-05, equal_nan=True)
         test_out.append(result)
-    
-    if not all(flag == True for (flag) in test_out):      
-        pdb.set_trace()  
+
     assert all(flag == True for (flag) in test_out)
 
 # Test with only slm.tri


### PR DESCRIPTION
- `SurfStatP.py` is born, its matlab version is wrapped and tests created `test_SurfStatP.py` .

- minor changes in `SurfStatResels.py` for its matlab compatibility : **reselspvert** converted from (v,) array to (1,v) and **edg** is added +1 and its dtype made sure to be int. These steps were necessary to be able to call  `SurfStatResels.py` in `SurfStatP.py`.

- minor changes in `test_SurfStatResels.py` : pdb removed, edg+1 is replaced with edg. 

- `SurfStatPeakClus.py` : this function changes slm['t'], even though it's not supposed to change it. Therefore, a deep copy of slm['t'] is set as a variable. This was necessary to be able call  `SurfStatPeakClus.py` in `SurfStatP.py`.

- OF NOTE: test_16 in  `test_SurfStatP.py`  fails. I doubt that it is because of a failure in `stat_threshold.py`. I will open a bug issue for this specifically. 