### PR TITLE
[FIX] CI now works on forks

### DIFF
--- a/.github/workflows/MATLAB_unittests.yml
+++ b/.github/workflows/MATLAB_unittests.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install numpy
-        git config remote.origin.fetch refs/heads/*:refs/remotes/origin/*
+        [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
         git fetch origin test-data
         git checkout origin/test-data -- extern/test-data
         git reset extern/test-data

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -20,11 +20,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+        git fetch origin test-data
         python -m pip install --upgrade pip
         pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        git config remote.origin.fetch refs/heads/*:refs/remotes/origin/*
-        git fetch origin test-data
     - name: Test with pytest
       run: |
         python3 -m pytest


### PR DESCRIPTION
This PR fixes CI on forks. Formerly, these would be unable to load the test-data. 