### PR TITLE
[REF] Replaces numpy_groupies with np.bincount

### DIFF
--- a/brainstat/mesh/data.py
+++ b/brainstat/mesh/data.py
@@ -1,7 +1,6 @@
 """Operations on data on a mesh."""
 
 import numpy as np
-from numpy_groupies import aggregate
 from .utils import mesh_edges
 import sys
 
@@ -91,8 +90,8 @@ def mesh_smooth(Y, surf, FWHM):
             isnum = True
 
     edg = mesh_edges(surf) + 1
-    agg_1 = aggregate(edg[:, 0], 2, size=(v + 1))
-    agg_2 = aggregate(edg[:, 1], 2, size=(v + 1))
+    agg_1 = np.bincount(edg[:, 0], minlength=(v + 1)) * 2
+    agg_2 = np.bincount(edg[:, 1], minlength=(v + 1)) * 2
     Y1 = (agg_1 + agg_2)[1:]
 
     if n > 1:
@@ -115,8 +114,8 @@ def mesh_smooth(Y, surf, FWHM):
 
                 for itera in range(1, niter + 1):
                     Yedg = Ys[edg[:, 0] - 1] + Ys[edg[:, 1] - 1]
-                    agg_tmp1 = aggregate(edg[:, 0], Yedg, size=(v + 1))[1:]
-                    agg_tmp2 = aggregate(edg[:, 1], Yedg, size=(v + 1))[1:]
+                    agg_tmp1 = np.bincount(edg[:, 0], Yedg, (v + 1))[1:]
+                    agg_tmp2 = np.bincount(edg[:, 1], Yedg, (v + 1))[1:]
                     Ys = (agg_tmp1 + agg_tmp2) / Y1
 
                 if np.ndim(Y) == 2:

--- a/brainstat/mesh/data.py
+++ b/brainstat/mesh/data.py
@@ -116,7 +116,8 @@ def mesh_smooth(Y, surf, FWHM):
                     Yedg = Ys[edg[:, 0] - 1] + Ys[edg[:, 1] - 1]
                     agg_tmp1 = np.bincount(edg[:, 0], Yedg, (v + 1))[1:]
                     agg_tmp2 = np.bincount(edg[:, 1], Yedg, (v + 1))[1:]
-                    Ys = (agg_tmp1 + agg_tmp2) / Y1
+                    with np.errstate(invalid='ignore'):
+                        Ys = (agg_tmp1 + agg_tmp2) / Y1
 
                 if np.ndim(Y) == 2:
                     Y[i, :] = Ys

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ nibabel
 nilearn>=0.7.0
 nimare
 numpy>=1.16.5
-numpy_groupies
 pandas
 scikit_learn
 scipy>=1.3.3

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setuptools.setup(
         "nilearn>=0.7.0",
         "nimare",
         "numpy>=1.16.5",
-        "numpy_groupies",
         "pandas",
         "scikit_learn",
         "scipy>=1.3.3",


### PR DESCRIPTION
Closes #138 

Replaces all instances of `numpy_groupies.aggregate` with equivalent calls to `np.bincount`.

Also removes dependency for `numpy_groupies` from setup.py and requirements.txt.

Finally, adds a context manager to `mesh_smooth` so that an "invalid value" warning isn't unnecessarily raised.