### PR TITLE
[REF] Updates context.genetics function

### DIFF
--- a/brainstat/context/genetics.py
+++ b/brainstat/context/genetics.py
@@ -1,53 +1,49 @@
 """Genetic decoding using abagen."""
 
-from abagen import get_expression_data
-from .utils import mutli_surface_to_volume
-import tempfile
+from abagen import check_atlas, get_expression_data
 
 
 def surface_genetic_expression(
-    pial,
-    white,
     labels,
-    volume_template,
+    surfaces=None,
+    space=None,
     *,
     atlas_info=None,
     ibf_threshold=0.5,
     probe_selection="diff_stability",
     donor_probes="aggregate",
-    lr_mirror=False,
-    exact=True,
+    lr_mirror=None,
+    missing=None,
     tolerance=2,
     sample_norm="srs",
     gene_norm="srs",
     norm_matched=True,
+    norm_structures=False,
     region_agg="donors",
     agg_metric="mean",
     corrected_mni=True,
     reannotated=True,
     return_counts=False,
     return_donors=False,
+    return_report=False,
     donors="all",
     data_dir=None,
-    verbose=1,
+    verbose=0,
     n_proc=1
 ):
     """Computes genetic expression of surface parcels.
 
     Parameters
     ----------
-    pial : str, BSPolyData, list
-        Path of a pial surface file, BSPolyData of a pial surface or a list
-        containing multiple of the aforementioned.
-    white : str, BSPolyData, list
-        Path of a white matter surface file, BSPolyData of a pial surface or a
-        list containing multiple of the aforementioned.
-    labels : str, numpy.ndarray, list
-        Path to a label file for the surfaces, numpy array containing the
-        labels, or a list containing multiple of the aforementioned.
-    volume_template : str, nibabel.nifti1.Nifti1Image
-        Path to a nifti file to use as a template for the surface to volume
-        procedure, or a loaded NIfTI image.
+    labels : list-of-str or numpy.ndarray
+        List of paths to label files for the parcellation, or numpy array
+        containing the pre-loaded labels
+    surfaces : list-of-image, optional
+        List of paths to surface files. If not specified assumes that `labels`
+        are on the `fsaverage5` surface. Default: None
+    space : {'fsaverage', 'fslr'}
+        What template space `surfaces` are aligned to. If not specified assumes
+        that `labels` are on the `fsaverage5` surface. Default: None
 
     For details of the remaining parameters please consult the
     abagen.get_expression_data() documentation. All its parameters bar "atlas"
@@ -58,56 +54,49 @@ def surface_genetic_expression(
     pandas.DataFrame
         Dataframe containing the expression of each gene within each region.
 
-    Notes
-    -----
-    An equal number of pial/white surfaces and labels must be provided. If
-    parcellations overlap across surfaces, then the labels are kept for the
-    first provided surface.
-
     Examples
     --------
     >>> from brainstat.context.genetics import surface_genetic_expression
     >>> from nilearn import datasets
+    >>> import numpy as np
 
+    >>> destrieux = datasets.fetch_atlas_surf_destrieux()
+    >>> labels = np.hstack((destrieux['map_left'], destrieux['map_right']))
     >>> fsaverage = datasets.fetch_surf_fsaverage()
-    >>> destrieux_atlas = datasets.fetch_atlas_surf_destrieux()
-    >>> parcellation = destrieux_atlas['map_left']
-    >>> mni152 = datasets.load_mni152_template()
-    >>> surface_genetic_expression(fsaverage['pial_left'], fsaverage['white_left'],
-    ...    parcellation, mni152)
+    >>> surfaces = (fsaverage['pial_left'], fsaverage['pial_right'])
+    >>> expression = surface_genetic_expression(labels, surfaces,
+    ...                                         space='fsaverage')
     """
 
-    with tempfile.NamedTemporaryFile(suffix=".nii.gz") as f:
-        mutli_surface_to_volume(
-            pial, white, volume_template, labels, f.name, verbose=verbose > 0
-        )
-
-        # Use abagen to grab expression data.
-        print(
-            "If you use BrainStat's genetics functionality, please cite abagen (https://abagen.readthedocs.io/en/stable/citing.html)."
-        )
-        expression = get_expression_data(
-            f.name,
-            atlas_info=atlas_info,
-            ibf_threshold=ibf_threshold,
-            probe_selection=probe_selection,
-            donor_probes=donor_probes,
-            lr_mirror=lr_mirror,
-            exact=exact,
-            tolerance=tolerance,
-            sample_norm=sample_norm,
-            gene_norm=gene_norm,
-            norm_matched=norm_matched,
-            region_agg=region_agg,
-            agg_metric=agg_metric,
-            corrected_mni=corrected_mni,
-            reannotated=reannotated,
-            return_counts=return_counts,
-            return_donors=return_donors,
-            donors=donors,
-            data_dir=data_dir,
-            verbose=verbose,
-            n_proc=n_proc,
-        )
+    # Use abagen to grab expression data.
+    print(
+        "If you use BrainStat's genetics functionality, please cite abagen (https://abagen.readthedocs.io/en/stable/citing.html)."
+    )
+    atlas = check_atlas(labels, geometry=surfaces, space=space)
+    expression = get_expression_data(
+        atlas,
+        atlas_info=atlas_info,
+        ibf_threshold=ibf_threshold,
+        probe_selection=probe_selection,
+        donor_probes=donor_probes,
+        lr_mirror=lr_mirror,
+        missing=missing,
+        tolerance=tolerance,
+        sample_norm=sample_norm,
+        gene_norm=gene_norm,
+        norm_matched=norm_matched,
+        norm_structures=norm_structures,
+        region_agg=region_agg,
+        agg_metric=agg_metric,
+        corrected_mni=corrected_mni,
+        reannotated=reannotated,
+        return_counts=return_counts,
+        return_donors=return_donors,
+        return_report=return_report,
+        donors=donors,
+        data_dir=data_dir,
+        verbose=verbose,
+        n_proc=n_proc,
+    )
 
     return expression

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-abagen
+abagen>=0.1
 brainspace>=0.1.1
 neurosynth
 nibabel

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     python_requires=">=3.6",
     test_require=["pytest", "gitpython"],
     install_requires=[
-        "abagen",
+        "abagen>=0.1",
         "brainspace>=0.1.1",
         "neurosynth",
         "nibabel",


### PR DESCRIPTION
Closes #137 

As of `abagen` v0.1 the main `abagen.get_expression_data` workflow supports surface atlases (in a variety of spaces; default: fsaverage5). This removes the surface -> volume projection from the `context.genetics` module and simply passes the surface parcellation directly to `abagen`.

Also, a few parameters were added / updated, and the minimum `abagen` version was pinned to 0.1 in both setup.py and requirements.txt.

Since this changes the API to `surface_genetic_expression` I'm more than happy to discuss / iterate exactly how it's exposed to users. Let me know if you'd prefer an alternative to the current handling of inputs.