### PR TITLE
[FIX] Set sphinx==3.5.4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx>=3.4.2
+Sphinx==3.5.4
 sphinxcontrib-matlabdomain
 sphinx_rtd_theme
 sphinx-gallery


### PR DESCRIPTION
Sphinx 4.0.0 results in errors during the build. This PR resolves this by setting sphinx version to 3.5.4