### PR TITLE
Datagen f

### DIFF
--- a/brainstat/tests/datagen_f.py
+++ b/brainstat/tests/datagen_f.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pickle
+from sklearn.model_selection import ParameterGrid
+from nilearn import datasets
+from brainspace.mesh.mesh_elements import get_cells
+from brainstat.stats._multiple_comparisons import peak_clus
+from brainstat.mesh.utils import mesh_edges
+from brainstat.context.utils import read_surface_gz
+from testutil import generate_slm, datadir
+from brainstat.stats.terms import FixedEffect
+from brainstat.stats.SLM import SLM, f_test
+
+
+def generate_random_two_slms(I):
+    slm1 = SLM(FixedEffect(1), FixedEffect(1))
+    slm2 = SLM(FixedEffect(1), FixedEffect(2))
+
+    for key in I.keys():
+        if "1" in key:
+            setattr(slm1, key[4:], I[key])
+        elif "2" in key:
+            setattr(slm2, key[4:], I[key])
+
+    return slm1, slm2
+
+
+def generate_f_test_out(slm1, slm2):
+    D = {}
+    slm_OUT = f_test(slm1, slm2)
+    mykeys = ['X', 'df', 'SSE', 'coef', 'k', 't']
+    for key in mykeys:
+        D[key] = getattr(slm_OUT, key)
+
+    return D
+
+
+def params2files(I, D, test_num):
+    """Converts params to input/output files"""
+    basename = "xstatf"
+    fin_name = datadir(basename + "_" + f"{test_num:02d}" + "_IN.pkl")
+    fout_name = datadir(basename + "_" + f"{test_num:02d}" + "_OUT.pkl")
+    with open(fin_name, "wb") as f:
+        pickle.dump(I, f, protocol=4)
+    with open(fout_name, "wb") as g:
+        pickle.dump(D, g, protocol=4)
+
+    return
+
+
+
+np.random.seed(0)
+
+a = 40
+b = 30
+c = 100
+d = 42
+e = 77
+
+mygrid = [{"slm1X": [np.random.randint(0, a, size=(a,b)),
+                  np.random.rand(a,b)],
+            "slm1df": [int(a)],
+            "slm2df": [int(b)],
+            "slm1SSE": [np.random.randint(1,a,size=(c,1)),
+                        np.random.randint(1, a, size=(c,d))],
+            "slm2SSE": [np.random.randint(1,a,size=(c,1)),
+                        np.random.randint(1, a, size=(c,d))],
+            "slm1coef": [np.random.rand(e,d),
+                         np.random.rand(e,d,3)],
+            "slm2coef": [np.random.rand(e,d)]
+    }] 
+
+    
+myparamgrid = ParameterGrid(mygrid)
+
+
+
+test_num = 0
+for params in myparamgrid:
+    test_num += 1
+    I = {}
+    for key in params.keys():
+        I[key] = params[key]
+    # make "slm2X" equal to "slm1X" to avoid nested-model error        
+    I["slm2X"] = I["slm1X"]
+    slm1, slm2 = generate_random_two_slms(I)
+    D = generate_f_test_out(slm1, slm2)
+    params2files(I,D,test_num)
+

--- a/brainstat/tests/datagen_f.py
+++ b/brainstat/tests/datagen_f.py
@@ -20,17 +20,15 @@ def generate_random_two_slms(I):
             setattr(slm1, key[4:], I[key])
         elif "2" in key:
             setattr(slm2, key[4:], I[key])
-
     return slm1, slm2
 
 
 def generate_f_test_out(slm1, slm2):
     D = {}
     slm_OUT = f_test(slm1, slm2)
-    mykeys = ['X', 'df', 'SSE', 'coef', 'k', 't']
+    mykeys = ["X", "df", "SSE", "coef", "k", "t"]
     for key in mykeys:
         D[key] = getattr(slm_OUT, key)
-
     return D
 
 
@@ -43,9 +41,7 @@ def params2files(I, D, test_num):
         pickle.dump(I, f, protocol=4)
     with open(fout_name, "wb") as g:
         pickle.dump(D, g, protocol=4)
-
     return
-
 
 
 np.random.seed(0)
@@ -56,23 +52,30 @@ c = 100
 d = 42
 e = 77
 
-mygrid = [{"slm1X": [np.random.randint(0, a, size=(a,b)),
-                  np.random.rand(a,b)],
-            "slm1df": [int(a)],
-            "slm2df": [int(b)],
-            "slm1SSE": [np.random.randint(1,a,size=(c,1)),
-                        np.random.randint(1, a, size=(c,d))],
-            "slm2SSE": [np.random.randint(1,a,size=(c,1)),
-                        np.random.randint(1, a, size=(c,d))],
-            "slm1coef": [np.random.rand(e,d),
-                         np.random.rand(e,d,3)],
-            "slm2coef": [np.random.rand(e,d)]
-    }] 
+mygrid = [
+    {
+        "slm1X": [np.random.randint(0, a, size=(a, b)), np.random.rand(a, b)],
+        "slm1df": [int(a)],
+        "slm2df": [int(b)],
+        "slm1SSE": [
+            np.random.randint(1, a, size=(c, 1)),
+            np.random.randint(1, a, size=(c, d)),
+        ],
+        "slm2SSE": [
+            np.random.randint(1, a, size=(c, 1)),
+            np.random.randint(1, a, size=(c, d)),
+        ],
+        "slm1coef": [np.random.rand(e, d), np.random.rand(e, d, 3)],
+        "slm2coef": [np.random.rand(e, d)],
+    }
+]
 
-    
 myparamgrid = ParameterGrid(mygrid)
 
-
+# Here wo go!
+# Test 1-16 : slm1X 2D array type int or float64, slm1df and slm2df int,
+# slm1SSE and slm2SSE 2D arrays type int, slm1coef and slm2coef 2D or 3D
+# arrays type float64
 
 test_num = 0
 for params in myparamgrid:
@@ -80,9 +83,8 @@ for params in myparamgrid:
     I = {}
     for key in params.keys():
         I[key] = params[key]
-    # make "slm2X" equal to "slm1X" to avoid nested-model error        
+    # make "slm2X" equal to "slm1X" to avoid nested-model error
     I["slm2X"] = I["slm1X"]
     slm1, slm2 = generate_random_two_slms(I)
     D = generate_f_test_out(slm1, slm2)
-    params2files(I,D,test_num)
-
+    params2files(I, D, test_num)

--- a/brainstat/tests/test_f_test.py
+++ b/brainstat/tests/test_f_test.py
@@ -44,222 +44,96 @@ def dummy_test(infile, expfile):
 
 
 def test_01():
-    # small sized slm1 and slm2 keys ['X'], ['df'], ['SSE'], ['coef']
-    # slm1X : np array, shape (5, 6), int64
-    # slm1df  : int
-    # slm1SSE : np array, shape (3, 1), int64
-    # slm1coef : np array, shape (6, 1), int64
-    # slm2X' : np array, shape (5, 6), int64
-    # slm2df' : int,
-    # slm2SSE' : np array, shape (3, 1), int64
-    # slm2coef' : np array, shape (6, 1), int64
-    infile = datadir("statf_01_IN.pkl")
-    expfile = datadir("statf_01_OUT.pkl")
+    infile = datadir("xstatf_01_IN.pkl")
+    expfile = datadir("xstatf_01_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_02():
-    # middle sized slm1 and slm2 keys ['X'], ['df'], ['SSE'], ['coef']
-    # slm1X : np array, shape (84, 77), int64
-    # slm1df : int
-    # slm1SSE : np array, shape (1128, 42), int64
-    # slm1coef : np array, shape (77, 42), int64
-    # slm2X : np array, shape (84, 77), int64
-    # slm2df : int
-    # slm2SSE : np array, shape (1128, 42), int64
-    # slm2coef : np array, shape (77, 42), int64
-    infile = datadir("statf_02_IN.pkl")
-    expfile = datadir("statf_02_OUT.pkl")
+    infile = datadir("xstatf_02_IN.pkl")
+    expfile = datadir("xstatf_02_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_03():
-    # middle sized slm1 and slm2 keys ['X'], ['df'], ['SSE'] + and ['SSE'] has 2k rows
-    # slm1X np array, shape (91, 58), float64
-    # slm1df : int
-    # slm1SSE : np array, shape (2278, 75), float64
-    # slm1coef : np array, shape (58, 75), float64
-    # slm2X : np array, shape (91, 58), float64
-    # slm2df : int
-    # slm2SSE : np array, shape (2278, 75), float64
-    # slm2coef : np array, shape (58, 75) float64
-    infile = datadir("statf_03_IN.pkl")
-    expfile = datadir("statf_03_OUT.pkl")
+    infile = datadir("xstatf_03_IN.pkl")
+    expfile = datadir("xstatf_03_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_04():
-    # small sized input slm1 and slm2 keys ['X'], ['df'], ['SSE'], ['coef'] is 3D
-    # slm1X : np array, shape (19, 27), int64
-    # slm1df : int
-    # slm1SSE : np array, shape (6, 87), int64
-    # slm1coef : np array, shape (27, 87, 3), float64
-    # slm2X : np array, shape (19, 27), int64
-    # slm2df : int
-    # slm2SSE : np array, shape (6, 87), int64
-    # slm2coef : np array, shape (27, 87, 3), float64
-    infile = datadir("statf_04_IN.pkl")
-    expfile = datadir("statf_04_OUT.pkl")
+    infile = datadir("xstatf_04_IN.pkl")
+    expfile = datadir("xstatf_04_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_05():
-    # similar to test_04, shapes of ['X'], ['SSE'] and ['coef'] changed
-    # slm1X : np array, shape (13, 3), int64
-    # slm1df : int
-    # slm1SSE : np array, shape (3, 27), int64
-    # slm1coef : np array, shape (3, 27, 2), float64
-    # slm2X : np array, shape (13, 3),  int64
-    # slm2df : int
-    # slm2SSE : np array, shape (3, 27), int64
-    # slm2coef np array, shape (3, 27, 2), float64
-    infile = datadir("statf_05_IN.pkl")
-    expfile = datadir("statf_05_OUT.pkl")
+    infile = datadir("xstatf_05_IN.pkl")
+    expfile = datadir("xstatf_05_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_06():
-    # similar to test_04, shapes/values of ['X'], ['SSE'], ['df'] and ['coef'] changed
-    # slm1X : np array, shape (13, 10), int64
-    # slm1df : int
-    # slm1SSE : np array, shape (3, 34), int64
-    # slm1coef : np array, shape (10, 34, 2), int64
-    # slm2X : np array, shape (13, 10), int64
-    # slm2df : int
-    # slm2SSE : np array, shape (3, 34), int64
-    # slm2coef : np array, shape (10, 34, 2), int64
-    infile = datadir("statf_06_IN.pkl")
-    expfile = datadir("statf_06_OUT.pkl")
+    infile = datadir("xstatf_06_IN.pkl")
+    expfile = datadir("xstatf_06_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_07():
-    # similar to test_04, shapes/values of ['X'], ['SSE'], ['df'] and ['coef'] changed
-    # slm1X : np array, shape (12, 4), float64
-    # slm1df : int
-    # slm1SSE : np array, shape (6, 42), float64
-    # slm1coef : np array, shape (4, 42, 3), float64
-    # slm2X : np array, shape (12, 4), float64
-    # slm2df : int
-    # slm2SSE np array, shape (6, 42), float64
-    # slm2coef np array, shape (4, 42, 3), float64
-    infile = datadir("statf_07_IN.pkl")
-    expfile = datadir("statf_07_OUT.pkl")
+    infile = datadir("xstatf_07_IN.pkl")
+    expfile = datadir("xstatf_07_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_08():
-    # similar to test_04, shapes/values of ['X'], ['SSE'], ['df'] and ['coef'] changed
-    # slm1X : np array, shape (32, 91), float64
-    # slm1df : int
-    # slm1SSE : np array, shape (3, 78), float64
-    # slm1coef : np array, shape (91, 78, 2), float64
-    # slm2X : np array, shape (32, 91), float64
-    # slm2df : int
-    # slm2SSE np array, shape (3, 78), float64
-    # slm2coef np array, shape (91, 78, 2), float64
-    infile = datadir("statf_08_IN.pkl")
-    expfile = datadir("statf_08_OUT.pkl")
+    infile = datadir("xstatf_08_IN.pkl")
+    expfile = datadir("xstatf_08_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_09():
-    # similar to test_04, shapes/values of ['X'], ['SSE'], ['df'] and ['coef'] changed
-    # slm1X : np array, shape (88, 49), float64
-    # slm1df : int
-    # slm1SSE : np array, shape (1, 56), float64
-    # slm1coef : np array, shape (49, 56, 1), float64
-    # slm2X : np array, shape (88, 49), float64
-    # slm2df : int
-    # slm2SSE : np array, shape (1, 56), float64
-    # slm2coef : np array, shape (49, 56, 1), float64
-    infile = datadir("statf_09_IN.pkl")
-    expfile = datadir("statf_09_OUT.pkl")
+    infile = datadir("xstatf_09_IN.pkl")
+    expfile = datadir("xstatf_09_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_10():
-    # real data set with more keys then ['X'], ['SSE'], ['df'] and ['coef'] given
-    # slm1X : np array, shape (10, 2), uint8
-    # slm1df : int
-    # slm1SSE : np array, shape (1, 20484), float64
-    # slm1coef : np array, shape (2, 20484), float64
-    # slm1tri : np array, shape (40960, 3), int32
-    # slm1resl : np array, shape (61440, 1), float64
-    # slm1c : np array, shape (1, 2), float64
-    # slm1k : int
-    # slm1ef : np array, shape (1, 20484), float64
-    # slm1sd : np array, shape (1, 20484), float64
-    # slm1t : np array, shape (1, 20484), float64
-    # slm2X : np array, shape (10, 2), uint8
-    # slm2df : int
-    # slm2SSE : np array, shape (1, 20484), float64
-    # slm2coef : np array, shape (2, 20484), float64
-    # slm2tri : np array, shape (40960, 3), int32
-    # slm2resl : np array, shape (61440, 1), float64
-    # slm2c : np array, shape (1, 2), float64
-    # slm2k : int
-    # slm2ef : np array, shape (1, 20484), float64
-    # slm2sd : np array, shape (1, 20484), float64
-    # slm2t : np array, shape (1, 20484), float64
-    infile = datadir("statf_10_IN.pkl")
-    expfile = datadir("statf_10_OUT.pkl")
+    infile = datadir("xstatf_10_IN.pkl")
+    expfile = datadir("xstatf_10_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_11():
-    # test_10 + slm2['resl'] and slm2[X] shuffled, slm2['df'] changed
-    # slm1X : np array, shape (10, 2), uint8
-    # slm1df : int
-    # slm1SSE : np array, shape (1, 20484), float64
-    # slm1coef : np array, shape (2, 20484), float64
-    # slm1tri : np array, shape (40960, 3), int32
-    # slm1resl : np array, shape (61440, 1), float64
-    # slm1c : np array, shape (1, 2), float64
-    # slm1k : int
-    # slm1ef : np array, shape (1, 20484), float64
-    # slm1sd : np array, shape (1, 20484), float64
-    # slm1t : np array, shape (1, 20484), float64
-    # slm2X : np array, shape (10, 2), uint8
-    # slm2df : int
-    # slm2SSE : np array, shape (1, 20484), float64
-    # slm2coef : np array, shape (2, 20484), float64
-    # slm2tri : np array, shape (40960, 3), int32
-    # slm2resl : np array, shape (61440, 1), float64
-    # slm2c : np array, shape (1, 2), float64
-    # slm2k : int
-    # slm2ef : np array, shape (1, 20484), float64
-    # slm2sd : np array, shape (1, 20484), float64
-    # slm2t : np array, shape (1, 20484), float64
-    infile = datadir("statf_11_IN.pkl")
-    expfile = datadir("statf_11_OUT.pkl")
+    infile = datadir("xstatf_11_IN.pkl")
+    expfile = datadir("xstatf_11_OUT.pkl")
     dummy_test(infile, expfile)
 
 
 def test_12():
-    # test_10 + shapes/values of ['X'], ['SSE'], ['df'] and ['coef'] changed
-    # slm1X : np array, shape (20, 9), uint16
-    # slm1df : int
-    # slm1SSE : np array, shape (1, 20484), float64
-    # slm1coef : np array, shape (9, 20484), float64
-    # slm1tri : np array, shape (40960, 3), int32
-    # slm1resl : np array, shape (61440, 1), float64
-    # slm1c : np array, shape (1, 9), float64
-    # slm1k : int
-    # slm1ef : np array, shape (1, 20484), float64
-    # slm1sd : np array, shape (1, 20484), float64
-    # slm1t : np array, shape (1, 20484), float64
-    # slm2X : np array, shape (20, 9), uint16
-    # slm2df : int
-    # slm2SSE : np array, shape (1, 20484), float64
-    # slm2coef : np array, shape (9, 20484), float64
-    # slm2tri : np array, shape (40960, 3), int32
-    # slm2resl : np array, shape (61440, 1), float64
-    # slm2c : np array, shape (1, 9), float64
-    # slm2k : int
-    # slm2ef : np array, shape (1, 20484), float64
-    # slm2sd : np array, shape (1, 20484), float64
-    # slm2t : np array, shape (1, 20484), float64
-    infile = datadir("statf_12_IN.pkl")
-    expfile = datadir("statf_12_OUT.pkl")
+    infile = datadir("xstatf_12_IN.pkl")
+    expfile = datadir("xstatf_12_OUT.pkl")
+    dummy_test(infile, expfile)
+
+
+def test_13():
+    infile = datadir("xstatf_13_IN.pkl")
+    expfile = datadir("xstatf_13_OUT.pkl")
+    dummy_test(infile, expfile)
+
+
+def test_14():
+    infile = datadir("xstatf_14_IN.pkl")
+    expfile = datadir("xstatf_14_OUT.pkl")
+    dummy_test(infile, expfile)
+
+
+def test_15():
+    infile = datadir("xstatf_15_IN.pkl")
+    expfile = datadir("xstatf_15_OUT.pkl")
+    dummy_test(infile, expfile)
+
+
+def test_16():
+    infile = datadir("xstatf_16_IN.pkl")
+    expfile = datadir("xstatf_16_OUT.pkl")
     dummy_test(infile, expfile)


### PR DESCRIPTION
Random test data generation for [test_f_test.py](https://github.com/MICA-MNI/BrainStat/blob/master/brainstat/tests/test_f_test.py).

I just realized that [f_test](https://github.com/MICA-MNI/BrainStat/blob/master/brainstat/stats/SLM.py#L250) runs independent of 'tri', 'resl', etc.. Therefore, I kept test data generation for both slm1 and slm2 minimal here, ie. without including fs5 stuff in any of the slm* objects.