### PR TITLE
[TST] Added windows/macos unit tests

### DIFF
--- a/.github/workflows/MATLAB_unittests.yml
+++ b/.github/workflows/MATLAB_unittests.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
 
 jobs:
+  matlab_unit_test:
   strategy:
     fail-fast: false
     matrix:
@@ -14,7 +15,6 @@ jobs:
 
   runs-on: ${{ matrix.os }}
   
-  matlab_unit_test:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/.github/workflows/MATLAB_unittests.yml
+++ b/.github/workflows/MATLAB_unittests.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   matlab_unit_test:
-  strategy:
-    fail-fast: false
-    matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+          os: [ubuntu-latest, windows-latest, macos-latest]
 
-  runs-on: ${{ matrix.os }}
-  
+    runs-on: ${{ matrix.os }}
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/.github/workflows/MATLAB_unittests.yml
+++ b/.github/workflows/MATLAB_unittests.yml
@@ -8,8 +8,10 @@ on:
 
 jobs:
   matlab_unit_test:
-    runs-on: ubuntu-latest
+    matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/.github/workflows/MATLAB_unittests.yml
+++ b/.github/workflows/MATLAB_unittests.yml
@@ -8,13 +8,8 @@ on:
 
 jobs:
   matlab_unit_test:
-    strategy:
-      fail-fast: false
-      matrix:
-          os: [ubuntu-latest, windows-latest, macos-latest]
-
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-latest
+    
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/.github/workflows/MATLAB_unittests.yml
+++ b/.github/workflows/MATLAB_unittests.yml
@@ -7,11 +7,14 @@ on:
   pull_request:
 
 jobs:
-  matlab_unit_test:
+  strategy:
+    fail-fast: false
     matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
-    runs-on: ${{ matrix.os }}
+  runs-on: ${{ matrix.os }}
+  
+  matlab_unit_test:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
@@ -19,6 +22,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install dependencies
+      shell: bash
       run: |
         python -m pip install numpy vtk
         [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -9,12 +9,13 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -24,26 +24,22 @@ jobs:
         python-version: ${{ matrix.python-version }}
    
    
-    - name: Install Ubuntu dependencies
-      run: |
-        echo ${{ matrix.os }}
-        if [ ${{ matrix.os }} != 'windows-latest' ] ; then
-          is_fork=[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
-        else
-          is_fork=( -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) )
-        fi
-
-        if $is_fork; then
-          git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
-        else
-          git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
-        fi
-      
+    - name: Install Ubuntu/macOS dependencies
+      if: matrix.os != 'windows-latest'
+      run: | 
+        [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
         git fetch origin test-data-2.0
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
+    - name: Install Windows dependencies
+      if: matrix.os == 'windows-latest'
+      run: | 
+        [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+        git fetch origin test-data-2.0
+        python -m pip install --upgrade pip
+        pip install pytest gitpython
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
         python3 -m pytest

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -22,7 +22,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+   
+   
+    - name: Install Ubuntu dependencies
+      if: matrix.os == 'ubuntu-latest' 
       run: |
         if [ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
         then
@@ -34,6 +37,36 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    
+     - name: Install macOS dependencies
+      if: matrix.os == 'macos-latest' 
+      run: |
+        if [ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
+        then
+          git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
+        else
+          git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+        fi
+        git fetch origin test-data-2.0
+        python -m pip install --upgrade pip
+        pip install pytest gitpython
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Install Windows dependencies
+      if: matrix.os == 'macos-latest' 
+      run: |
+        if ( -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) )
+        then
+          git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
+        else
+          git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+        fi
+        git fetch origin test-data-2.0
+        python -m pip install --upgrade pip
+        pip install pytest gitpython
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+
     - name: Test with pytest
       run: |
         python3 -m pytest

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -26,34 +26,19 @@ jobs:
    
     - name: Install Ubuntu dependencies
       run: |
-        OS="$OSTYPE"
-        case $OS in
-          'linux*')
-            OS='linux'
-            ;;
-          'msys*')
-            OS='windows'
-            ;;
-          'darwin*') 
-            OS='mac'
-            ;;
-        esac
-
-        if [ $OS == 'mac' ] | [ $OS == 'linux' ]; then
-          if [ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
-          then
-            git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
-          else
-            git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
-          fi
+        echo ${{ matrix.os }}
+        if [ ${{ matrix.os }} != 'windows-latest' ] |; then
+          is_fork=[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
         else
-          if ( -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) )
-          then
-            git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
-          else
-            git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
-          fi
+          is_fork=( -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) )
         fi
+
+        if $is_fork; then
+          git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
+        else
+          git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+        fi
+      
         git fetch origin test-data-2.0
         python -m pip install --upgrade pip
         pip install pytest gitpython

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -25,44 +25,40 @@ jobs:
    
    
     - name: Install Ubuntu dependencies
-      if: matrix.os == 'ubuntu-latest' 
       run: |
-        if [ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
-        then
-          git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
+        OS="`uname`"
+        case $OS in
+          'Linux')
+            OS='linux'
+            ;;
+          'Windows*')
+            OS='windows'
+            ;;
+          'Darwin') 
+            OS='mac'
+            ;;
+        esac
+
+        if [ $OS == 'mac' ] | [ $OS == 'linux' ]; then
+          if [ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
+          then
+            git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
+          else
+            git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+          fi
         else
-          git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+          if ( -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) )
+          then
+            git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
+          else
+            git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+          fi
         fi
         git fetch origin test-data-2.0
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-     - name: Install macOS dependencies
-      if: matrix.os == 'macos-latest' 
-      run: |
-        if [ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
-        then
-          git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
-        else
-          git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
-        fi
-        git fetch origin test-data-2.0
-        python -m pip install --upgrade pip
-        pip install pytest gitpython
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Install Windows dependencies
-      if: matrix.os == 'macos-latest' 
-      run: |
-        if ( -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) )
-        then
-          git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
-        else
-          git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
-        fi
-        git fetch origin test-data-2.0
-        python -m pip install --upgrade pip
-        pip install pytest gitpython
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
     - name: Test with pytest
       run: |
         python3 -m pytest

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -24,7 +24,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+        if [ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
+        then
+          git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/*
+        else
+          git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
+        fi
         git fetch origin test-data-2.0
         python -m pip install --upgrade pip
         pip install pytest gitpython

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -26,15 +26,15 @@ jobs:
    
     - name: Install Ubuntu dependencies
       run: |
-        OS="`uname`"
+        OS="$OSTYPE"
         case $OS in
-          'Linux')
+          'linux*')
             OS='linux'
             ;;
-          'Windows*')
+          'msys*')
             OS='windows'
             ;;
-          'Darwin') 
+          'darwin*') 
             OS='mac'
             ;;
         esac

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -25,6 +25,7 @@ jobs:
    
    
     - name: Install Ubuntu/macOS dependencies
+      shell: bash
       if: matrix.os != 'windows-latest'
       run: | 
         [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
@@ -32,15 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Install Windows dependencies
-      if: matrix.os == 'windows-latest'
-      run: | 
-        [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
-        git fetch origin test-data-2.0
-        python -m pip install --upgrade pip
-        pip install pytest gitpython
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      shell: bash
+
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -37,7 +37,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    
      - name: Install macOS dependencies
       if: matrix.os == 'macos-latest' 
       run: |
@@ -51,7 +50,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
       - name: Install Windows dependencies
       if: matrix.os == 'macos-latest' 
       run: |
@@ -65,8 +63,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-
     - name: Test with pytest
       run: |
         python3 -m pytest

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -40,6 +40,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      shell: bash
+
     - name: Test with pytest
       run: |
         python3 -m pytest

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -26,7 +26,6 @@ jobs:
    
     - name: Install Ubuntu/macOS dependencies
       shell: bash
-      if: matrix.os != 'windows-latest'
       run: | 
         [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
         git fetch origin test-data-2.0

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Ubuntu dependencies
       run: |
         echo ${{ matrix.os }}
-        if [ ${{ matrix.os }} != 'windows-latest' ] |; then
+        if [ ${{ matrix.os }} != 'windows-latest' ] ; then
           is_fork=[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]
         else
           is_fork=( -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) )

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -23,8 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
    
-   
-    - name: Install Ubuntu/macOS dependencies
+    - name: Install Dependencies
       shell: bash
       run: | 
         [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
@@ -32,7 +31,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest gitpython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
 
     - name: Test with pytest
       run: |

--- a/brainstat/tests/testutil.py
+++ b/brainstat/tests/testutil.py
@@ -1,8 +1,9 @@
 """Utilities for running tests and test data generation."""
-import os
 import numpy as np
 import pickle
 import vtk
+from pathlib import Path
+import brainstat
 from brainstat.stats.SLM import SLM
 from brainstat.stats.terms import FixedEffect, MixedEffect
 from brainspace.vtk_interface import wrap_vtk
@@ -10,11 +11,22 @@ from brainspace.vtk_interface.wrappers.data_object import BSPolyData
 from brainspace.mesh.mesh_elements import get_cells, get_points
 
 
-def datadir(file):
-    topdir = os.path.dirname(__file__)
-    topdir = os.path.join(topdir, "../../")
-    topdir = os.path.abspath(topdir)
-    return os.path.join(topdir, "extern/test-data", file)
+def datadir(filename):
+    """Returns the path to a given file in the test data directory.
+
+    Parameters
+    ----------
+    filename : str
+        Name of a file in the data directory.
+
+    Returns
+    -------
+    str
+        Full path to file in the data directory.
+    """
+    test_dir = Path(brainstat.__file__)
+    repo_dir = test_dir.parents[1]
+    return str(repo_dir / "extern" / "test-data" / filename)
 
 
 def generate_slm(**kwargs):


### PR DESCRIPTION
This PR expands the unit tests with macOS and Windows unit tests for Python. To that end, it alters `brainstat.tests.testutil.datadir` to be compatible with Windows. 

MATLAB remains Ubuntu only because the MATLAB runner is not available on macOS and Windows. 

- Closes #176.