### PR TITLE
[REF] Enforce usage of intercept and identity matrix

### DIFF
--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -423,7 +423,14 @@ class MixedEffect:
     """
 
     def __init__(
-        self, ran=None, fix=None, name_ran=None, name_fix=None, ranisvar=False, add_intercept=True, add_identity=True,
+        self,
+        ran=None,
+        fix=None,
+        name_ran=None,
+        name_fix=None,
+        ranisvar=False,
+        add_intercept=True,
+        add_identity=True,
     ):
 
         if isinstance(ran, MixedEffect):
@@ -452,12 +459,12 @@ class MixedEffect:
         self.mean = FixedEffect(fix, names=name_fix, add_intercept=add_intercept)
 
         if add_identity:
-            I = MixedEffect(1, name_ran='I', add_identity=False)
+            I = MixedEffect(1, name_ran="I", add_identity=False)
             tmp_mixed = self + I
             self.variance = tmp_mixed.variance
 
         self.set_identity_last()
-    
+
     def set_identity_last(self):
         """Sets the identity matrix column last.
 
@@ -479,7 +486,6 @@ class MixedEffect:
         else:
             raise ValueError('Found the name "I" twice in the dataframe names.')
 
-
     def broadcast_to(self, r1, r2):
         if r1.variance.shape[0] == 1:
             v = np.eye(max(r2.shape[0], int(np.sqrt(r2.shape[2]))))
@@ -499,7 +505,9 @@ class MixedEffect:
             ran = r.variance + self.variance
             fix = r.mean + self.mean
 
-        s = MixedEffect(ran=ran, fix=fix, ranisvar=True, add_intercept=False, add_identity=False)
+        s = MixedEffect(
+            ran=ran, fix=fix, ranisvar=True, add_intercept=False, add_identity=False
+        )
         s.set_identity_last()
         return s
 
@@ -520,7 +528,9 @@ class MixedEffect:
         else:
             ran = r.variance - self.variance
             fix = r.mean - self.mean
-        return MixedEffect(ran=ran, fix=fix, ranisvar=True, add_intercept=False, add_identity=False)
+        return MixedEffect(
+            ran=ran, fix=fix, ranisvar=True, add_intercept=False, add_identity=False
+        )
 
     def __sub__(self, r):
         return self._sub(r)
@@ -540,7 +550,9 @@ class MixedEffect:
         else:
             ran = r.variance * self.variance
             fix = r.mean * self.mean
-        s = MixedEffect(ran=ran, fix=fix, ranisvar=True, add_intercept=False, add_identity=False)
+        s = MixedEffect(
+            ran=ran, fix=fix, ranisvar=True, add_intercept=False, add_identity=False
+        )
 
         x = self.mean.matrix.values.T / self.mean.matrix.abs().values.max()
         t = FixedEffect()
@@ -624,5 +636,11 @@ def Term(x=None, names=None):
 @deprecated("Please use MixedEffect instead.")
 def Random(ran=None, fix=None, name_ran=None, name_fix=None, ranisvar=False):
     return MixedEffect(
-        ran=ran, fix=fix, name_ran=name_ran, name_fix=name_fix, ranisvar=ranisvar, add_intercept=False, add_identity = False
+        ran=ran,
+        fix=fix,
+        name_ran=name_ran,
+        name_fix=name_fix,
+        ranisvar=ranisvar,
+        add_intercept=False,
+        add_identity=False,
     )

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -147,7 +147,9 @@ def remove_identical_columns(df1, df2):
     for col in names:
         if np.array_equal(df1[col], df2[col]):
             df1 = df1.drop(col, axis=1)
-        elif (df1[col].size == 1 or df2[col].size == 1) and np.all(df1[col].to_numpy() == df2[col].to_numpy()):
+        elif (df1[col].size == 1 or df2[col].size == 1) and np.all(
+            df1[col].to_numpy() == df2[col].to_numpy()
+        ):
             # Assume its an intercept term.
             df1 = df1.drop(col, axis=1)
         else:

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -573,9 +573,13 @@ class MixedEffect:
                         xd_name = f"({self.mean.names[i]}-{self.mean.names[j]})"
 
                         v = np.outer(xs, xs) / 4
-                        t = t + FixedEffect(v.ravel(), names=xs_name, add_intercept=False)
+                        t = t + FixedEffect(
+                            v.ravel(), names=xs_name, add_intercept=False
+                        )
                         v = np.outer(xd, xd) / 4
-                        t = t + FixedEffect(v.ravel(), names=xd_name, add_intercept=False)
+                        t = t + FixedEffect(
+                            v.ravel(), names=xd_name, add_intercept=False
+                        )
 
             s.variance = s.variance + t * r.variance
 
@@ -595,9 +599,13 @@ class MixedEffect:
                         xd_name = f"({r.mean.names[i]}-{r.mean.names[j]})"
 
                         v = np.outer(xs, xs) / 4
-                        t = t + FixedEffect(v.ravel(), names=xs_name, add_intercept=False)
+                        t = t + FixedEffect(
+                            v.ravel(), names=xs_name, add_intercept=False
+                        )
                         v = np.outer(xd, xd) / 4
-                        t = t + FixedEffect(v.ravel(), names=xd_name, add_intercept=False)
+                        t = t + FixedEffect(
+                            v.ravel(), names=xd_name, add_intercept=False
+                        )
             s.variance = s.variance + self.variance * t
         s.set_identity_last()
         return s

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -477,15 +477,22 @@ class MixedEffect:
         if self.variance.is_empty:
             return
 
-        idx = np.argwhere(["I" == x for x in self.variance.names])
-        if idx.size == 0:
+        if self.variance.m.size == 1:
+            # Class is the identity.
             return
-        elif idx.size == 1:
+
+        n = int(round(np.sqrt(self.variance.m.shape[0])))
+        I = np.reshape(np.identity(n), (-1, 1))
+        index = np.argwhere(np.all(self.variance.m.to_numpy() == I, axis=0))
+
+        if index.size == 0:
+            return
+        elif index.size == 1:
             names = self.variance.names
-            names.append(names.pop(idx[0][0]))
+            names.append(names.pop(index[0][0]))
             self.variance.m = self.variance.m[names]
         else:
-            raise ValueError('Found the name "I" twice in the dataframe names.')
+            raise ValueError("Found the identity matrix twice in the dataframe.")
 
     def broadcast_to(self, r1, r2):
         if r1.variance.shape[0] == 1:

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -481,8 +481,9 @@ class MixedEffect:
         if idx.size == 0:
             return
         elif idx.size == 1:
-            self.variance.names.append(self.variance.names.pop(idx[0][0]))
-            self.variance.m = self.variance.m[self.variance.names]
+            names = self.variance.names
+            names.append(names.pop(idx[0][0]))
+            self.variance.m = self.variance.m[names]
         else:
             raise ValueError('Found the name "I" twice in the dataframe names.')
 
@@ -554,48 +555,50 @@ class MixedEffect:
             ran=ran, fix=fix, ranisvar=True, add_intercept=False, add_identity=False
         )
 
-        x = self.mean.matrix.values.T / self.mean.matrix.abs().values.max()
-        t = FixedEffect()
-        for i in range(x.shape[0]):
-            for j in range(i + 1):
-                if i == j:
-                    t = t + FixedEffect(
-                        np.outer(x[i], x[j]).T.ravel(),
-                        names=self.mean.names[i],
-                        add_intercept=False,
-                    )
-                else:
-                    xs = x[i] + x[j]
-                    xs_name = f"({self.mean.names[i]}+{self.mean.names[j]})"
-                    xd = x[i] - x[j]
-                    xd_name = f"({self.mean.names[i]}-{self.mean.names[j]})"
+        if self.mean.matrix.values.size > 0:
+            x = self.mean.matrix.values.T / self.mean.matrix.abs().values.max()
+            t = FixedEffect()
+            for i in range(x.shape[0]):
+                for j in range(i + 1):
+                    if i == j:
+                        t = t + FixedEffect(
+                            np.outer(x[i], x[j]).T.ravel(),
+                            names=self.mean.names[i],
+                            add_intercept=False,
+                        )
+                    else:
+                        xs = x[i] + x[j]
+                        xs_name = f"({self.mean.names[i]}+{self.mean.names[j]})"
+                        xd = x[i] - x[j]
+                        xd_name = f"({self.mean.names[i]}-{self.mean.names[j]})"
 
-                    v = np.outer(xs, xs) / 4
-                    t = t + FixedEffect(v.ravel(), names=xs_name, add_intercept=False)
-                    v = np.outer(xd, xd) / 4
-                    t = t + FixedEffect(v.ravel(), names=xd_name, add_intercept=False)
+                        v = np.outer(xs, xs) / 4
+                        t = t + FixedEffect(v.ravel(), names=xs_name, add_intercept=False)
+                        v = np.outer(xd, xd) / 4
+                        t = t + FixedEffect(v.ravel(), names=xd_name, add_intercept=False)
 
-        s.variance = s.variance + t * r.variance
+            s.variance = s.variance + t * r.variance
 
-        x = r.mean.matrix.values.T / r.mean.matrix.abs().values.max()
-        t = FixedEffect()
-        for i in range(x.shape[0]):
-            for j in range(i + 1):
-                if i == j:
-                    t = t + FixedEffect(
-                        np.outer(x[i], x[j]).ravel(), names=r.mean.names[i]
-                    )
-                else:
-                    xs = x[i] + x[j]
-                    xs_name = f"({r.mean.names[i]}+{r.mean.names[j]})"
-                    xd = x[i] - x[j]
-                    xd_name = f"({r.mean.names[i]}-{r.mean.names[j]})"
+        if r.mean.matrix.values.size > 0:
+            x = r.mean.matrix.values.T / r.mean.matrix.abs().values.max()
+            t = FixedEffect()
+            for i in range(x.shape[0]):
+                for j in range(i + 1):
+                    if i == j:
+                        t = t + FixedEffect(
+                            np.outer(x[i], x[j]).ravel(), names=r.mean.names[i]
+                        )
+                    else:
+                        xs = x[i] + x[j]
+                        xs_name = f"({r.mean.names[i]}+{r.mean.names[j]})"
+                        xd = x[i] - x[j]
+                        xd_name = f"({r.mean.names[i]}-{r.mean.names[j]})"
 
-                    v = np.outer(xs, xs) / 4
-                    t = t + FixedEffect(v.ravel(), names=xs_name, add_intercept=False)
-                    v = np.outer(xd, xd) / 4
-                    t = t + FixedEffect(v.ravel(), names=xd_name, add_intercept=False)
-        s.variance = s.variance + self.variance * t
+                        v = np.outer(xs, xs) / 4
+                        t = t + FixedEffect(v.ravel(), names=xs_name, add_intercept=False)
+                        v = np.outer(xd, xd) / 4
+                        t = t + FixedEffect(v.ravel(), names=xd_name, add_intercept=False)
+            s.variance = s.variance + self.variance * t
         s.set_identity_last()
         return s
 

--- a/brainstat/tests/test_linear_model.py
+++ b/brainstat/tests/test_linear_model.py
@@ -17,15 +17,9 @@ def dummy_test(infile, expfile):
     M = Din["M"]
 
     # Convert M to a true BrainStat model
-    fixed_effects = FixedEffect(1, "intercept") + FixedEffect(M[:, Din["n_random"] :])
+    fixed_effects = FixedEffect(M[:, Din["n_random"] :])
     if Din["n_random"] != 0:
-        mixed_effects = (
-            MixedEffect(
-                M[:, : Din["n_random"]],
-                name_ran=["f" + str(x) for x in range(Din["n_random"])],
-            )
-            + MixedEffect(1, "identity")
-        )
+        mixed_effects = MixedEffect(M[:, : Din["n_random"]],name_ran=["f" + str(x) for x in range(Din["n_random"])],)
         M = fixed_effects + mixed_effects
     else:
         M = fixed_effects

--- a/brainstat/tests/test_linear_model.py
+++ b/brainstat/tests/test_linear_model.py
@@ -19,7 +19,10 @@ def dummy_test(infile, expfile):
     # Convert M to a true BrainStat model
     fixed_effects = FixedEffect(M[:, Din["n_random"] :])
     if Din["n_random"] != 0:
-        mixed_effects = MixedEffect(M[:, : Din["n_random"]],name_ran=["f" + str(x) for x in range(Din["n_random"])],)
+        mixed_effects = MixedEffect(
+            M[:, : Din["n_random"]],
+            name_ran=["f" + str(x) for x in range(Din["n_random"])],
+        )
         M = fixed_effects + mixed_effects
     else:
         M = fixed_effects

--- a/brainstat/tests/test_terms.py
+++ b/brainstat/tests/test_terms.py
@@ -1,35 +1,35 @@
 from brainstat.stats.terms import FixedEffect, MixedEffect
 import numpy as np
 
+
 def test_fixed_intercept():
-    random_data = np.random.random_sample((10,1))
-    fix1 = FixedEffect(random_data, ['x0'])
-    fix2 = FixedEffect(random_data, ['x0'], add_intercept=False)
+    random_data = np.random.random_sample((10, 1))
+    fix1 = FixedEffect(random_data, ["x0"])
+    fix2 = FixedEffect(random_data, ["x0"], add_intercept=False)
 
     assert np.array_equal(fix1.m.shape, [10, 2])
-    assert np.array_equal(fix1.names, ['intercept', 'x0'])
+    assert np.array_equal(fix1.names, ["intercept", "x0"])
     assert np.array_equal(fix2.m.shape, [10, 1])
-    assert np.array_equal(fix2.names, ['x0'])
+    assert np.array_equal(fix2.names, ["x0"])
 
 
 def test_fixed_overload():
-    random_data = np.random.random_sample((10,3))
-    fix01 = FixedEffect(random_data[:, :2], ['x0', 'x1'], add_intercept=False)
-    fix12 = FixedEffect(random_data[:, 1:], ['x2', 'x3'], add_intercept=False)
-    fix2 = FixedEffect(random_data[:, 2], ['x2'], add_intercept=False)
-    fixi0 = FixedEffect(random_data[:, 0], ['x0'], add_intercept=True)
-    fixi1 = FixedEffect(random_data[:, 1], ['x1'], add_intercept=True)
+    random_data = np.random.random_sample((10, 3))
+    fix01 = FixedEffect(random_data[:, :2], ["x0", "x1"], add_intercept=False)
+    fix12 = FixedEffect(random_data[:, 1:], ["x2", "x3"], add_intercept=False)
+    fix2 = FixedEffect(random_data[:, 2], ["x2"], add_intercept=False)
+    fixi0 = FixedEffect(random_data[:, 0], ["x0"], add_intercept=True)
+    fixi1 = FixedEffect(random_data[:, 1], ["x1"], add_intercept=True)
 
     fix_add = fix01 + fix12
     assert np.array_equal(fix_add.m, random_data)
 
     fix_add_intercept = fixi0 + fixi1
-    expected = np.concatenate((np.ones((10,1)), random_data[:,0:2]), axis=1)
+    expected = np.concatenate((np.ones((10, 1)), random_data[:, 0:2]), axis=1)
     assert np.array_equal(fix_add_intercept.m, expected)
 
     fix_sub = fix01 - fix12
-    assert np.array_equal(fix_sub.m, random_data[:,0][:, None])
+    assert np.array_equal(fix_sub.m, random_data[:, 0][:, None])
 
     fix_mul = fix01 * fix2
     assert np.array_equal(fix_mul.m, random_data[:, :2] * random_data[:, 2][:, None])
-

--- a/brainstat/tests/test_terms.py
+++ b/brainstat/tests/test_terms.py
@@ -95,6 +95,18 @@ def test_mixed_overload():
     assert np.array_equal(mix_mul.variance.m, expected_mul)
 
 
+def test_identity_detection():
+    """Tests that the identity matrix is correctly placed last."""
+    mix1 = MixedEffect(np.random.rand(3, 1), add_identity=False)
+    mix2 = MixedEffect(1, name_ran="test_identity")
+    I = np.identity(3).flatten()
+
+    mix_add1 = mix2 + mix1
+    mix_add2 = mix1 + mix2
+    assert np.all(mix_add1.variance.m.to_numpy()[:, 1] == I)
+    assert np.all(mix_add2.variance.m.to_numpy()[:, 1] == I)
+
+
 def as_variance(M):
     var = [np.reshape(x[:, None] @ x[None, :], (-1, 1)) for x in M.T]
     return np.squeeze(var, axis=2).T

--- a/brainstat/tests/test_terms.py
+++ b/brainstat/tests/test_terms.py
@@ -5,20 +5,20 @@ import numpy as np
 
 
 def test_fixed_init():
-    """ Tests the initialization of the FixedEffect class. """
+    """Tests the initialization of the FixedEffect class."""
     random_data = np.random.random_sample((10, 1))
     fix1 = FixedEffect(random_data, ["x0"])
     fix2 = FixedEffect(random_data, ["x0"], add_intercept=False)
 
     assert np.array_equal(fix1.m.shape, [10, 2])
     assert np.array_equal(fix1.names, ["intercept", "x0"])
-    
+
     assert np.array_equal(fix2.m.shape, [10, 1])
     assert np.array_equal(fix2.names, ["x0"])
 
 
 def test_fixed_overload():
-    """ Tests the overloads of the FixedEffect class. """
+    """Tests the overloads of the FixedEffect class."""
     random_data = np.random.random_sample((10, 3))
     fix01 = FixedEffect(random_data[:, :2], ["x0", "x1"], add_intercept=False)
     fix12 = FixedEffect(random_data[:, 1:], ["x2", "x3"], add_intercept=False)
@@ -44,33 +44,33 @@ def test_fixed_overload():
 
 
 def test_mixed_init():
-    """ Tests the initialization of the MixedEffect class. """
+    """Tests the initialization of the MixedEffect class."""
     n = 10
     random_data = np.random.random_sample((n, 1))
     mix1 = MixedEffect(random_data, ["x0"])
     mix2 = MixedEffect(random_data, ["x0"], add_identity=False)
     mix3 = MixedEffect(random_data, random_data, ["x0"], ["y0"])
     mix4 = MixedEffect(random_data, random_data, ["x0"], ["y0"], add_intercept=False)
-    
-    assert np.array_equal(mix1.variance.shape, [n**2, 2])
+
+    assert np.array_equal(mix1.variance.shape, [n ** 2, 2])
     assert np.array_equal(mix1.variance.names, ["x0", "I"])
-    
-    assert np.array_equal(mix2.variance.shape, [n**2, 1])
+
+    assert np.array_equal(mix2.variance.shape, [n ** 2, 1])
     assert np.array_equal(mix2.variance.names, ["x0"])
-    
+
     assert np.array_equal(mix3.mean.shape, [10, 2])
     assert np.array_equal(mix3.mean.names, ["intercept", "y0"])
-    
+
     assert np.array_equal(mix4.mean.shape, [10, 1])
     assert np.array_equal(mix4.mean.names, ["y0"])
 
 
 def test_mixed_overload():
-    """ Tests the overloads of the MixedEffect class. """
-    n = 10
+    """Tests the overloads of the MixedEffect class."""
+    n = 3
     random_data = np.random.random_sample((n, 4))
-    mix1 = MixedEffect(random_data[:,0], name_ran=["x0"])
-    mix2 = MixedEffect(random_data[:,1], name_ran=["x1"])
+    mix1 = MixedEffect(random_data[:, 0], name_ran=["x0"])
+    mix2 = MixedEffect(random_data[:, 1], name_ran=["x1"])
 
     I = np.identity(n).flatten()[:, None]
     var12 = as_variance(random_data[:, :2])
@@ -83,8 +83,17 @@ def test_mixed_overload():
     assert mix_sub.empty
 
     mix_mul = mix1 * mix2
-    expected_mul = np.concatenate((var12[:,0][:, None] * var12[:,1][:, None], I), axis=1)
+    expected_mul = np.concatenate(
+        (
+            var12[:, 0][:, None] * var12[:, 1][:, None],
+            var12[:, 1][:, None] * I,
+            var12[:, 0][:, None] * I,
+            I,
+        ),
+        axis=1,
+    )
     assert np.array_equal(mix_mul.variance.m, expected_mul)
+
 
 def as_variance(M):
     var = [np.reshape(x[:, None] @ x[None, :], (-1, 1)) for x in M.T]

--- a/brainstat/tests/test_terms.py
+++ b/brainstat/tests/test_terms.py
@@ -1,19 +1,24 @@
+""" Tests the fixed and mixed effects classes. """
+
 from brainstat.stats.terms import FixedEffect, MixedEffect
 import numpy as np
 
 
-def test_fixed_intercept():
+def test_fixed_init():
+    """ Tests the initialization of the FixedEffect class. """
     random_data = np.random.random_sample((10, 1))
     fix1 = FixedEffect(random_data, ["x0"])
     fix2 = FixedEffect(random_data, ["x0"], add_intercept=False)
 
     assert np.array_equal(fix1.m.shape, [10, 2])
     assert np.array_equal(fix1.names, ["intercept", "x0"])
+    
     assert np.array_equal(fix2.m.shape, [10, 1])
     assert np.array_equal(fix2.names, ["x0"])
 
 
 def test_fixed_overload():
+    """ Tests the overloads of the FixedEffect class. """
     random_data = np.random.random_sample((10, 3))
     fix01 = FixedEffect(random_data[:, :2], ["x0", "x1"], add_intercept=False)
     fix12 = FixedEffect(random_data[:, 1:], ["x2", "x3"], add_intercept=False)
@@ -24,6 +29,9 @@ def test_fixed_overload():
     fix_add = fix01 + fix12
     assert np.array_equal(fix_add.m, random_data)
 
+    fix_add_intercept = 1 + FixedEffect(random_data[:, 0])
+    assert np.array_equal(fixi0.m, fix_add_intercept.m)
+
     fix_add_intercept = fixi0 + fixi1
     expected = np.concatenate((np.ones((10, 1)), random_data[:, 0:2]), axis=1)
     assert np.array_equal(fix_add_intercept.m, expected)
@@ -33,3 +41,51 @@ def test_fixed_overload():
 
     fix_mul = fix01 * fix2
     assert np.array_equal(fix_mul.m, random_data[:, :2] * random_data[:, 2][:, None])
+
+
+def test_mixed_init():
+    """ Tests the initialization of the MixedEffect class. """
+    n = 10
+    random_data = np.random.random_sample((n, 1))
+    mix1 = MixedEffect(random_data, ["x0"])
+    mix2 = MixedEffect(random_data, ["x0"], add_identity=False)
+    mix3 = MixedEffect(random_data, random_data, ["x0"], ["y0"])
+    mix4 = MixedEffect(random_data, random_data, ["x0"], ["y0"], add_intercept=False)
+    
+    assert np.array_equal(mix1.variance.shape, [n**2, 2])
+    assert np.array_equal(mix1.variance.names, ["x0", "I"])
+    
+    assert np.array_equal(mix2.variance.shape, [n**2, 1])
+    assert np.array_equal(mix2.variance.names, ["x0"])
+    
+    assert np.array_equal(mix3.mean.shape, [10, 2])
+    assert np.array_equal(mix3.mean.names, ["intercept", "y0"])
+    
+    assert np.array_equal(mix4.mean.shape, [10, 1])
+    assert np.array_equal(mix4.mean.names, ["y0"])
+
+
+def test_mixed_overload():
+    """ Tests the overloads of the MixedEffect class. """
+    n = 10
+    random_data = np.random.random_sample((n, 4))
+    mix1 = MixedEffect(random_data[:,0], name_ran=["x0"])
+    mix2 = MixedEffect(random_data[:,1], name_ran=["x1"])
+
+    I = np.identity(n).flatten()[:, None]
+    var12 = as_variance(random_data[:, :2])
+
+    mix_add = mix1 + mix2
+    expected_add = np.concatenate((var12, I), axis=1)
+    assert np.array_equal(mix_add.variance.m, expected_add)
+
+    mix_sub = mix1 - mix1
+    assert mix_sub.empty
+
+    mix_mul = mix1 * mix2
+    expected_mul = np.concatenate((var12[:,0][:, None] * var12[:,1][:, None], I), axis=1)
+    assert np.array_equal(mix_mul.variance.m, expected_mul)
+
+def as_variance(M):
+    var = [np.reshape(x[:, None] @ x[None, :], (-1, 1)) for x in M.T]
+    return np.squeeze(var, axis=2).T

--- a/brainstat/tests/test_terms.py
+++ b/brainstat/tests/test_terms.py
@@ -1,0 +1,35 @@
+from brainstat.stats.terms import FixedEffect, MixedEffect
+import numpy as np
+
+def test_fixed_intercept():
+    random_data = np.random.random_sample((10,1))
+    fix1 = FixedEffect(random_data, ['x0'])
+    fix2 = FixedEffect(random_data, ['x0'], add_intercept=False)
+
+    assert np.array_equal(fix1.m.shape, [10, 2])
+    assert np.array_equal(fix1.names, ['intercept', 'x0'])
+    assert np.array_equal(fix2.m.shape, [10, 1])
+    assert np.array_equal(fix2.names, ['x0'])
+
+
+def test_fixed_overload():
+    random_data = np.random.random_sample((10,3))
+    fix01 = FixedEffect(random_data[:, :2], ['x0', 'x1'], add_intercept=False)
+    fix12 = FixedEffect(random_data[:, 1:], ['x2', 'x3'], add_intercept=False)
+    fix2 = FixedEffect(random_data[:, 2], ['x2'], add_intercept=False)
+    fixi0 = FixedEffect(random_data[:, 0], ['x0'], add_intercept=True)
+    fixi1 = FixedEffect(random_data[:, 1], ['x1'], add_intercept=True)
+
+    fix_add = fix01 + fix12
+    assert np.array_equal(fix_add.m, random_data)
+
+    fix_add_intercept = fixi0 + fixi1
+    expected = np.concatenate((np.ones((10,1)), random_data[:,0:2]), axis=1)
+    assert np.array_equal(fix_add_intercept.m, expected)
+
+    fix_sub = fix01 - fix12
+    assert np.array_equal(fix_sub.m, random_data[:,0][:, None])
+
+    fix_mul = fix01 * fix2
+    assert np.array_equal(fix_mul.m, random_data[:, :2] * random_data[:, 2][:, None])
+

--- a/brainstat/tests/testutil.py
+++ b/brainstat/tests/testutil.py
@@ -228,15 +228,12 @@ def array2effect(A, n_random=0):
     brainstat.stats.terms.FixedEffect, brainstat.stats.terms.MixedEffect
         The fixed/mixed effects.
     """
-    fixed_effects = FixedEffect(1, "intercept") + FixedEffect(A[:, n_random:])
+    fixed_effects = FixedEffect(A[:, n_random:])
     if n_random != 0:
-        mixed_effects = (
-            MixedEffect(
+        mixed_effects = MixedEffect(
                 A[:, :n_random],
                 name_ran=["f" + str(x) for x in range(n_random)],
             )
-            + MixedEffect(1, "identity")
-        )
         return fixed_effects + mixed_effects
     else:
         return fixed_effects

--- a/brainstat/tests/testutil.py
+++ b/brainstat/tests/testutil.py
@@ -231,9 +231,9 @@ def array2effect(A, n_random=0):
     fixed_effects = FixedEffect(A[:, n_random:])
     if n_random != 0:
         mixed_effects = MixedEffect(
-                A[:, :n_random],
-                name_ran=["f" + str(x) for x in range(n_random)],
-            )
+            A[:, :n_random],
+            name_ran=["f" + str(x) for x in range(n_random)],
+        )
         return fixed_effects + mixed_effects
     else:
         return fixed_effects

--- a/brainstat_matlab/stats/@FixedEffect/FixedEffect.m
+++ b/brainstat_matlab/stats/@FixedEffect/FixedEffect.m
@@ -57,7 +57,13 @@ classdef FixedEffect
     end
 
     methods
-        function obj = FixedEffect(x, names)
+        function obj = FixedEffect(x, names, add_intercept)
+            arguments
+                x = []
+                names string = ""
+                add_intercept logical = true
+            end
+            
             % If no input.
             if nargin == 0
                 obj.names = [];
@@ -83,11 +89,11 @@ classdef FixedEffect
             % usage)
             elseif isnumeric(x) && ~isscalar(x) 
                 % Grab the term name. 
-                if nargin < 2
+                if names == ""
                     names = inputname(1);
-                end
-                if isempty(names)
-                    names = '?';
+                    if isempty(names)
+                        names = '?';
+                    end
                 end
                 names = string(names); 
                 
@@ -103,7 +109,11 @@ classdef FixedEffect
             
             % If x is an numeric scalar. 
             elseif isnumeric(x) && isscalar(x)
-                obj.names = string(x);
+                if exist('names', 'var')
+                    obj.names = string(names);
+                else
+                    obj.names = string(x);
+                end
                 obj.matrix = double(x);
             
             % If x is a structure.
@@ -113,6 +123,11 @@ classdef FixedEffect
                 for ii = 1:length(obj.names)
                     obj.matrix = [obj.matrix double(x.(obj.names{ii}))];
                 end                    
+            end
+            
+            % Add an intercept if none exists.
+            if add_intercept && ~any(all(obj.matrix == 1))
+                obj = FixedEffect(1, 'intercept', false) + obj;
             end
         end
     end

--- a/brainstat_matlab/stats/@FixedEffect/minus.m
+++ b/brainstat_matlab/stats/@FixedEffect/minus.m
@@ -2,8 +2,8 @@ function s=minus(t1,t2)
 if (~isa(t1,'FixedEffect') && numel(t1)>1) || (~isa(t2,'FixedEffect') && numel(t2)>1)
     warning('If you don''t convert vectors to terms you can get unexpected results :-(') 
 end
-t1=FixedEffect(t1,inputname(1));
-t2=FixedEffect(t2,inputname(2));
+t1=FixedEffect(t1,inputname(1), false);
+t2=FixedEffect(t2,inputname(2), false);
 if isempty(t1) || isempty(t2)
     s=t1;
     return
@@ -19,10 +19,10 @@ if n2==1
 end
 m1=t1.matrix./repmat(sum(abs(t1.matrix)),n,1);
 m2=t2.matrix./repmat(sum(abs(t2.matrix)),n,1);
-[d,i1]=setdiff(m1',m2','rows');
+[~,i1]=setdiff(m1',m2','rows');
 i1=sort(i1);
 
-s = FixedEffect(t1.matrix(:,i1),t1.names(i1));
+s = FixedEffect(t1.matrix(:,i1), t1.names(i1), false);
 
 
 % s.names=t1.names(i1);

--- a/brainstat_matlab/stats/@FixedEffect/mpower.m
+++ b/brainstat_matlab/stats/@FixedEffect/mpower.m
@@ -1,5 +1,5 @@
 function s=mpower(t,p)
-t=FixedEffect(t,inputname(1));
+t=FixedEffect(t, inputname(1), false);
 if p>=2
     s=mtimes(t,mpower(t,p-1));
 else 

--- a/brainstat_matlab/stats/@FixedEffect/mtimes.m
+++ b/brainstat_matlab/stats/@FixedEffect/mtimes.m
@@ -2,8 +2,8 @@ function s=mtimes(t1,t2)
 if (~isa(t1,'FixedEffect') && numel(t1)>1) | (~isa(t2,'FixedEffect') && numel(t2)>1)
     warning('If you don''t convert vectors to terms you can get unexpected results :-(') 
 end
-t1=FixedEffect(t1,inputname(1));
-t2=FixedEffect(t2,inputname(2));
+t1=FixedEffect(t1,inputname(1), false);
+t2=FixedEffect(t2,inputname(2), false);
 if isempty(t1) | isempty(t2)
     s=FixedEffect();
     return
@@ -19,7 +19,7 @@ if n2==1
 end
 k1=size(t1.matrix,2);
 k2=size(t2.matrix,2);
-nms=cell(1,k1*k2);
+nms=strings(1,k1*k2);
 x=zeros(n,k1*k2);
 for i2=1:k2
     for i1=1:k1
@@ -41,7 +41,7 @@ m=x./repmat(sum(abs(x)),n,1);
 j=sort(k1*k2-j+1);
 jj=j(any(x(:,j)));
 
-s = FixedEffect(x(:,jj),nms(jj));
+s = FixedEffect(x(:,jj),nms(jj), false);
 
 %s.names=nms(jj);
 %s.matrix=x(:,jj);

--- a/brainstat_matlab/stats/@FixedEffect/plus.m
+++ b/brainstat_matlab/stats/@FixedEffect/plus.m
@@ -2,8 +2,10 @@ function s=plus(t1,t2)
 if (~isa(t1,'FixedEffect') && numel(t1)>1) || (~isa(t2,'FixedEffect') && numel(t2)>1)
     warning('If you don''t convert vectors to terms you can get unexpected results :-(') 
 end
-t1=FixedEffect(t1,inputname(1));
-t2=FixedEffect(t2,inputname(2));
+
+t1=FixedEffect(t1, inputname(1), false);
+t2=FixedEffect(t2, inputname(2), false);
+
 if isempty(t1)
     s=t2;
     return
@@ -23,11 +25,18 @@ if n2==1
 end
 m1=t1.matrix./repmat(sum(abs(t1.matrix)),n,1);
 m2=t2.matrix./repmat(sum(abs(t2.matrix)),n,1);
-[u,i2,i1]=union(flipud(m2'),flipud(m1'),'rows');
+[~,i2,i1]=union(flipud(m2'),flipud(m1'),'rows');
 i1=sort(size(t1.matrix,2)-i1+1);
 i2=sort(size(t2.matrix,2)-i2+1);
 
-s = FixedEffect([t1.matrix(:,i1), t2.matrix(:,i2)], [t1.names(i1), t2.names(i2)]);
+if isempty(i1)
+    names = t2.names(i2);
+elseif isempty(i2)
+    names = t1.names(i1);
+else
+    names = [t1.names(i1), t2.names(i2)];
+end
+s = FixedEffect([t1.matrix(:,i1), t2.matrix(:,i2)], names, false);
 
 % s.names=[t1.names(i1), t2.names(i2)];    
 % s.matrix=[t1.matrix(:,i1), t2.matrix(:,i2)];

--- a/brainstat_matlab/stats/@MixedEffect/MixedEffect.m
+++ b/brainstat_matlab/stats/@MixedEffect/MixedEffect.m
@@ -99,6 +99,8 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
             
             % Parse input
             p = inputParser;
+            addOptional(p,'add_identity', true, @islogical)
+            addOptional(p,'add_intercept', true, @islogical);
             addOptional(p,'name_ran', 'ran', @(x) ischar(x) || isempty(x));
             addOptional(p,'name_fix', [], @(x) ischar(x) || iscell(x) || isstring(x) || isempty(x))
             addOptional(p,'ranisvar', [], @(x)(islogical(x) || x == 0 || x == 1) && numel(x) == 1);
@@ -132,11 +134,11 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
                 if R.ranisvar
                     % If the random term is already a variance term, simply set
                     % the variance. 
-                    obj.variance = FixedEffect(ran,R.name_ran);
+                    obj.variance = FixedEffect(ran, R.name_ran, false);
                 else
                     if numel(ran) == 1
                         % If the random term is a scalar, set the name to
-                        % I. (Why?)
+                        % I.
                         if ran == 1
                             R.name_ran = 'I';
                         else
@@ -146,14 +148,19 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
                     
                     % Compute the variance and set it. 
                     v = double(ran)*double(ran)';
-                    obj.variance = FixedEffect(v(:), R.name_ran);
+                    obj.variance = FixedEffect(v(:), R.name_ran, false);
                 end
             end
                 
             if ~isempty(fix)
                 % Set the fixed effect. 
-                obj.mean = FixedEffect(fix,R.name_fix);
+                obj.mean = FixedEffect(fix, R.name_fix, R.add_intercept);
             end
+            
+            if R.add_identity 
+                obj = obj + MixedEffect(1, [], 'name_ran', 'I', 'add_identity', false);
+            end
+            obj = obj.set_identity_last();
         end
     end
 end

--- a/brainstat_matlab/stats/@MixedEffect/minus.m
+++ b/brainstat_matlab/stats/@MixedEffect/minus.m
@@ -5,19 +5,21 @@ if (~isa(m1,'FixedEffect') && ~isa(m1,'MixedEffect') && numel(m1)>1) || ...
     warning('If you don''t convert vectors to terms you can get unexpected results :-(') 
 end
 if ~isa(m1,'MixedEffect')
-    m1=MixedEffect([],m1,[],inputname(1));
+    m1=MixedEffect([], m1, 'name_fix', inputname(1), 'add_identity', false, 'add_intercept', false);
 end
 if ~isa(m2,'MixedEffect')
-    m2=MixedEffect([],m2,[],inputname(2));
+    m2=MixedEffect([], m2, 'name_fix', inputname(2), 'add_identity', false, 'add_intercept', false);
 end
 
 if size(m1,3)==1
     v=eye(max(size(m2,1),sqrt(size(m2,3))));   
-    m1.variance=FixedEffect(v(:),'I');
+    m1.variance=FixedEffect(v(:),'I', false);
 end
 if size(m2,3)==1
     v=eye(max(size(m1,1),sqrt(size(m1,3))));
-    m2.variance=FixedEffect(v(:),'I');
+    m2.variance=FixedEffect(v(:),'I', false);
 end
 
-s = MixedEffect(m1.variance - m2.variance, m1.mean - m2.mean, [] ,[], true);
+s = MixedEffect(m1.variance - m2.variance, m1.mean - m2.mean, ...
+    'ranisvar', true, 'add_identity', false, 'add_intercept', false);
+s = s.set_identity_last();

--- a/brainstat_matlab/stats/@MixedEffect/mtimes.m
+++ b/brainstat_matlab/stats/@MixedEffect/mtimes.m
@@ -5,19 +5,19 @@ if (~isa(m1,'FixedEffect') && ~isa(m1,'MixedEffect') && numel(m1)>1) || ...
     warning('If you don''t convert vectors to terms you can get unexpected results :-(') 
 end
 if ~isa(m1,'MixedEffect')
-    m1=MixedEffect([],m1,[],inputname(1));
+    m1=MixedEffect([], m1, 'name_fix', inputname(1), 'add_identity', false, 'add_intercept', false);
 end
 if ~isa(m2,'MixedEffect')
-    m2=MixedEffect([],m2,[],inputname(2));
+    m2=MixedEffect([], m2, 'name_fix', inputname(2), 'add_identity', false, 'add_intercept', false);
 end
 
 if size(m1,3)==1
     v=eye(max(size(m2,1),sqrt(size(m2,3))));   
-    m1.variance=FixedEffect(v(:),'I');
+    m1.variance=FixedEffect(v(:),'I', false);
 end
 if size(m2,3)==1
     v=eye(max(size(m1,1),sqrt(size(m1,3))));
-    m2.variance=FixedEffect(v(:),'I');
+    m2.variance=FixedEffect(v(:),'I', false);
 end
 
 mean=m1.mean*m2.mean;
@@ -33,12 +33,12 @@ if ~isempty(N)
         for j=1:i
             if i==j
                 v=X(:,i)*X(:,i)';
-                t=t+FixedEffect(v(:),N{i});
+                t=t+FixedEffect(v(:),N{i}, false);
             else
                 v=(X(:,i)+X(:,j))*(X(:,i)+X(:,j))'/4;
-                t=t+FixedEffect(v(:),['(' N{j} '+' N{i} ')']);
+                t=t+FixedEffect(v(:),['(' N{j} '+' N{i} ')'], false);
                 v=(X(:,i)-X(:,j))*(X(:,i)-X(:,j))'/4;
-                t=t+FixedEffect(v(:),['(' N{j} '-' N{i} ')']);
+                t=t+FixedEffect(v(:),['(' N{j} '-' N{i} ')'], false);
             end
         end
     end
@@ -58,16 +58,17 @@ if ~isempty(N)
                 t=t+FixedEffect(v(:),N{i});
             else
                 v=(X(:,i)+X(:,j))*(X(:,i)+X(:,j))'/4;
-                t=t+FixedEffect(v(:),['(' N{j} '+' N{i} ')']);
+                t=t+FixedEffect(v(:),['(' N{j} '+' N{i} ')'], false);
                 v=(X(:,i)-X(:,j))*(X(:,i)-X(:,j))'/4;
-                t=t+FixedEffect(v(:),['(' N{j} '-' N{i} ')']);
+                t=t+FixedEffect(v(:),['(' N{j} '-' N{i} ')'], false);
             end
         end
     end
     variance = variance + m1.variance*t;
 end
 
-s = MixedEffect(variance,mean,[],[],true);
+s = MixedEffect(variance,mean, 'ranisvar', true, 'add_identity', false, 'add_intercept', false);
+s = s.set_identity_last();
 
 return
 end

--- a/brainstat_matlab/stats/@MixedEffect/plus.m
+++ b/brainstat_matlab/stats/@MixedEffect/plus.m
@@ -5,24 +5,21 @@ if (~isa(m1,'FixedEffect') && ~isa(m1,'MixedEffect') && numel(m1)>1) || ...
     warning('If you don''t convert vectors to terms you can get unexpected results :-(') 
 end
 if ~isa(m1,'MixedEffect')
-    m1=MixedEffect([],m1,[],inputname(1));
+    m1=MixedEffect([], m1, 'name_fix', inputname(1), 'add_identity', false, 'add_intercept', false);
 end
 if ~isa(m2,'MixedEffect')
-    m2=MixedEffect([],m2,[],inputname(2));
+    m2=MixedEffect([], m2, 'name_fix', inputname(2), 'add_identity', false, 'add_intercept', false);
 end
 
 if size(m1,3)==1
     v=eye(max(size(m2,1),sqrt(size(m2,3))));   
-    m1.variance=FixedEffect(v(:),'I');
+    m1.variance=FixedEffect(v(:),'I', false);
 end
 if size(m2,3)==1
     v=eye(max(size(m1,1),sqrt(size(m1,3))));
-    m2.variance=FixedEffect(v(:),'I');
+    m2.variance=FixedEffect(v(:),'I', false);
 end
 
-s = MixedEffect(m1.variance + m2.variance, m1.mean + m2.mean, [] ,[], true);
-
-
-%s.mean=m1.mean+m2.mean;
-%s.variance=m1.variance+m2.variance;
-%s=class(s,'MixedEffect');
+s = MixedEffect(m1.variance + m2.variance, m1.mean + m2.mean, ...
+    'ranisvar', true, 'add_identity', false, 'add_intercept', false);
+s = s.set_identity_last();

--- a/brainstat_matlab/stats/@MixedEffect/set_identity_last.m
+++ b/brainstat_matlab/stats/@MixedEffect/set_identity_last.m
@@ -4,7 +4,9 @@ if isempty(obj.variance)
     return
 end
 
-idx = find(obj.variance.names == "I", 1);
+n = sqrt(size(obj.variance.matrix,1));
+I = eye(n);
+idx = find(all(obj.variance.matrix == I(:)), 1);
 if isempty(idx)
     return
 end

--- a/brainstat_matlab/stats/@MixedEffect/set_identity_last.m
+++ b/brainstat_matlab/stats/@MixedEffect/set_identity_last.m
@@ -1,0 +1,15 @@
+function obj = set_identity_last(obj)
+
+if isempty(obj.variance)
+    return
+end
+
+idx = find(obj.variance.names == "I", 1);
+if isempty(idx)
+    return
+end
+
+if idx ~= numel(obj.variance.names)
+    obj.variance.names([idx, end]) = obj.variance.names([end, idx]);
+    obj.variance.matrix(:, [idx, end]) = obj.variance.matrix(:, [end, idx]);
+end

--- a/brainstat_matlab/tests/@test_term_random_overloads/test_term_random_overloads.m
+++ b/brainstat_matlab/tests/@test_term_random_overloads/test_term_random_overloads.m
@@ -75,5 +75,16 @@ classdef test_term_random_overloads < matlab.unittest.TestCase
             
             testCase.verifyEqual(as_variance(v1).^2, powerr.variance.matrix);
         end
+        
+        function test_identity_detection(testCase)
+            r1 = MixedEffect(rand(3,1), [], 'add_identity', false);
+            r2 = MixedEffect(1, [], 'name_ran', 'test_identity');
+            I = eye(3);
+            
+            r12 = r1 + r2;
+            r21 = r2 + r1;
+            testCase.verifyEqual(r12.variance.matrix(:,2), I(:));
+            testCase.verifyEqual(r21.variance.matrix(:,2), I(:));
+        end
     end
 end

--- a/brainstat_matlab/tests/@test_term_random_overloads/test_term_random_overloads.m
+++ b/brainstat_matlab/tests/@test_term_random_overloads/test_term_random_overloads.m
@@ -2,8 +2,8 @@ classdef test_term_random_overloads < matlab.unittest.TestCase
     methods (Test)
         function test_subsref(testCase)
             v1 = rand(100,2);
-            t1 = FixedEffect(v1);
-            r1 = MixedEffect(v1);
+            t1 = FixedEffect(v1, "", false);
+            r1 = MixedEffect(v1, [], 'add_identity', false);
             
             testCase.verifyEqual(t1.matrix, v1);
             testCase.verifyEqual(t1.names, ["v11","v12"]);
@@ -17,8 +17,8 @@ classdef test_term_random_overloads < matlab.unittest.TestCase
         
         function test_size(testCase)
             v1 = rand(100,2);
-            t1 = FixedEffect(v1);
-            r1 = MixedEffect(v1);
+            t1 = FixedEffect(v1, "", false);
+            r1 = MixedEffect(v1, [], 'add_identity', false, 'add_intercept', false);
             
             % Test size.
             testCase.verifyEqual(size(t1),size(v1));
@@ -28,11 +28,11 @@ classdef test_term_random_overloads < matlab.unittest.TestCase
         function test_math(testCase)
             v1 = rand(100,2);
             v2 = rand(100,2);
-            t1 = FixedEffect(v1);
-            t2 = FixedEffect([v1,v2]);
-            t3 = FixedEffect(v2);
-            r1 = MixedEffect(v1);
-            r3 = MixedEffect(v2);
+            t1 = FixedEffect(v1, "", false);
+            t2 = FixedEffect([v1,v2], "", false);
+            t3 = FixedEffect(v2, "", false);
+            r1 = MixedEffect(v1, [], 'add_identity', false);
+            r3 = MixedEffect(v2, [], 'add_identity', false);
             as_variance = @(x)reshape(x*x',[],1);
             
             % Test plus.

--- a/docs/matlab/tutorials/tutorial_1.rst
+++ b/docs/matlab/tutorials/tutorial_1.rst
@@ -19,20 +19,15 @@ Next, we can create the model by simply adding the terms together.
 
 .. code-block:: matlab
 
-   intercept = FixedEffect(1); 
    term_age = FixedEffect(demographic_data.AGE); 
    term_iq = FixedEffect(demographic_data.IQ); 
-   model = intercept + term_age + term_iq;
-
-   % Note that + 1 can be used as a shorthand for the intercept.
-   % In other words, model2 == model1
-   model2 = 1 + term_age + term_iq;
+   model = term_age + term_iq;
 
 We can also add an interaction effect to the model by multiplying age and handedness.
 
 .. code-block:: matlab
 
-   model_interaction = 1 + term_age + term_iq + ...
+   model_interaction = term_age + term_iq + ...
       term_age * term_iq;
 
 Now, lets imagine we have some cortical marker (e.g. cortical thickness) for
@@ -69,9 +64,8 @@ class instead, all other code remains identical.
 .. code-block:: matlab
 
    random_handedness = MixedEffect(demographic_data.HAND == "L");
-   random_identity = MixedEffect(1); % Note: "I" can be used as a shorthand. 
-   model_random = 1 + term_age + term_iq + term_age * term_iq ...
-      + random_handedness + random_identity;
+   model_random = term_age + term_iq + term_age * term_iq ...
+      + random_handedness;
    
    BrainStatModel_random = SLM(model_random, -demographic_data.AGE, ...
       'surf', surfaces);

--- a/docs/python/tutorials/plot_tutorial_01_basics.py
+++ b/docs/python/tutorials/plot_tutorial_01_basics.py
@@ -84,11 +84,7 @@ random_handedness = MixedEffect(
 )
 random_identity = MixedEffect(1, name_ran="identity")
 model_random = (
-    term_age
-    + term_iq
-    + term_age * term_iq
-    + random_handedness
-    + random_identity
+    term_age + term_iq + term_age * term_iq + random_handedness + random_identity
 )
 slm_random = SLM(model_random, -age, surf=pial_left, correction="fdr", mask=mask)
 slm_random.fit(thickness)

--- a/docs/python/tutorials/plot_tutorial_01_basics.py
+++ b/docs/python/tutorials/plot_tutorial_01_basics.py
@@ -41,15 +41,14 @@ pial_left = read_surface_gz(fetch_surf_fsaverage()["pial_left"])
 
 from brainstat.stats.terms import FixedEffect
 
-term_intercept = FixedEffect(1, names="intercept")
 term_age = FixedEffect(age, "age")
 term_iq = FixedEffect(iq, "iq")
-model = term_intercept + term_age + term_iq
+model = term_age + term_iq
 
 ###################################################################
 # We can also add interaction effects to the model by multiplying terms.
 
-model_interaction = term_intercept + term_age + term_iq + term_age * term_iq
+model_interaction = term_age + term_iq + term_age * term_iq
 
 ###################################################################
 # Now, lets imagine we have some cortical marker (e.g. cortical thickness) for
@@ -85,8 +84,7 @@ random_handedness = MixedEffect(
 )
 random_identity = MixedEffect(1, name_ran="identity")
 model_random = (
-    term_intercept
-    + term_age
+    term_age
     + term_iq
     + term_age * term_iq
     + random_handedness

--- a/docs/python/tutorials/plot_tutorial_01_basics.py
+++ b/docs/python/tutorials/plot_tutorial_01_basics.py
@@ -82,10 +82,8 @@ from brainstat.stats.terms import MixedEffect
 random_handedness = MixedEffect(
     tutorial_data["demographics"]["HAND"], name_ran="Handedness"
 )
-random_identity = MixedEffect(1, name_ran="identity")
-model_random = (
-    term_age + term_iq + term_age * term_iq + random_handedness + random_identity
-)
+
+model_random = term_age + term_iq + term_age * term_iq + random_handedness
 slm_random = SLM(model_random, -age, surf=pial_left, correction="fdr", mask=mask)
 slm_random.fit(thickness)
 


### PR DESCRIPTION
This PR will enforce the addition of an intercept to fixed effects and an identity matrix to mixed effects unless otherwise specified by the user. MATLAB implementation is finished. To that end, a new parameter has been added to the Fixed and Mixed effect classes called `add_intercept` (default: true), and `add_identity` (default: true) was added to MixedEffect.