### PR TITLE
[GIT] Add Python 3.9 to unit tests

### DIFF
--- a/.github/workflows/development_release.yml
+++ b/.github/workflows/development_release.yml
@@ -2,7 +2,8 @@ name: "development_release"
 
 on:
   push:
-    - development
+    branches:
+      - development
 
 jobs:
   development-release:

--- a/.github/workflows/development_release.yml
+++ b/.github/workflows/development_release.yml
@@ -1,0 +1,33 @@
+name: "development_release"
+
+on:
+  push:
+    - development
+
+jobs:
+  development-release:
+    name: "Development Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up Python 3.8.
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    
+    - name: Install Python BrainStat.
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build --user
+    
+    - name: Build binary wheel and tarball.
+      run: |
+        python -m build --sdist --wheel --outdir dist/
+
+    - name: Publish to PyPi test.
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/docs/generic/install.rst
+++ b/docs/generic/install.rst
@@ -9,8 +9,7 @@ BrainStat is available in Python and MATLAB.
 Python installation
 -------------------
 
-BrainStat is compatible with Python 3.6-3.8. Compatibility with 3.9 is in the
-works.
+BrainStat is compatible with Python 3.6+. 
 
 The latest version of BrainStat can be installed using ``pip``: ::
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    python_requires=">=3.6.*, !=3.9.*, !=3.10.*",
+    python_requires=">=3.6.*",
     test_require=["pytest", "gitpython"],
     install_requires=[
         "abagen>=0.1",


### PR DESCRIPTION
This PR adds Python 3.9 to the unit tests, updates the installation guide and setup.py and enables pushing to test-pypi on the development branch. 

- Closes #168.