### PR TITLE
[FIX] Fix automatic naming of mixed effects

### DIFF
--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -487,13 +487,14 @@ class MixedEffect:
                 else:
                     if name_ran is None:
                         name = check_names(ran)
-                        name_ran = name[0] if name else None
-                        for i in range(1, len(name)):
-                            sm = difflib.SequenceMatcher(None, name_ran, name[i])
-                            match = sm.find_longest_match(
-                                0, len(name_ran), 0, len(name[i])
-                            )
-                            name_ran = name_ran[match.a : match.a + match.size]
+                        if name:
+                            name_ran = name[0]
+                            for i in range(1, len(name)):
+                                sm = difflib.SequenceMatcher(None, name_ran, name[i])
+                                match = sm.find_longest_match(
+                                    0, len(name_ran), 0, len(name[i])
+                                )
+                                name_ran = name_ran[match.a : match.a + match.size]
 
                 ran = ran @ ran.T
                 ran = ran.values.ravel()

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -1,4 +1,5 @@
 """Classes for fixed, mixed, and random effects."""
+import difflib
 import re
 from typing import Any, List, Optional, Sequence, Union
 
@@ -484,12 +485,18 @@ class MixedEffect:
                     if v != 1:
                         name_ran += f"{v}**2"
                 else:
-                    name = check_names(ran)
-                    if name is not None and name_ran is None:
-                        name_ran = name
+                    if name_ran is None:
+                        name = check_names(ran)
+                        name_ran = name[0] if name else None
+                        for i in range(1, len(name)):
+                            sm = difflib.SequenceMatcher(None, name_ran, name[i])
+                            match = sm.find_longest_match(
+                                0, len(name_ran), 0, len(name[i])
+                            )
+                            name_ran = name_ran[match.a : match.a + match.size]
+
                 ran = ran @ ran.T
                 ran = ran.values.ravel()
-
             self.variance = FixedEffect(ran, names=name_ran, add_intercept=False)
         self.mean = FixedEffect(fix, names=name_fix, add_intercept=add_intercept)
 


### PR DESCRIPTION
- Resolves #265 . 

This fix isn't perfect; given the example code in issue #265 it'll still leave a trailing underscore i.e. `term_site.variance.name == "SITE_ID_"`. But it'll do for now. 