### PR TITLE
[ENH] Added a warning if an Effect contains nan/inf

### DIFF
--- a/brainstat_matlab/stats/@FixedEffect/FixedEffect.m
+++ b/brainstat_matlab/stats/@FixedEffect/FixedEffect.m
@@ -111,7 +111,7 @@ classdef FixedEffect
                 obj.matrix = double(x); 
                 if run_checks
                     brainstat_utils.check_categorical_variables(obj.matrix, obj.names);
-                    if any(isnan(obj.matrix)) || any(isinf(obj.matrix))
+                    if any(isnan(obj.matrix(:))) || any(isinf(obj.matrix(:)))
                         warning('BrainStat:FixedEffect', 'The data contains NaNs or Infs. Model fitting may error.');
                     end
                 end

--- a/brainstat_matlab/stats/@FixedEffect/FixedEffect.m
+++ b/brainstat_matlab/stats/@FixedEffect/FixedEffect.m
@@ -112,7 +112,7 @@ classdef FixedEffect
                 if run_checks
                     brainstat_utils.check_categorical_variables(obj.matrix, obj.names);
                     if any(isnan(obj.matrix(:))) || any(isinf(obj.matrix(:)))
-                        warning('BrainStat:FixedEffect', 'The data contains NaNs or Infs. Model fitting may error.');
+                        warning('BrainStat:FixedEffect', 'Input contains NaNs or Infs. This may cause errors in model fitting.');
                     end
                 end
             

--- a/brainstat_matlab/stats/@FixedEffect/FixedEffect.m
+++ b/brainstat_matlab/stats/@FixedEffect/FixedEffect.m
@@ -53,12 +53,12 @@ classdef FixedEffect
     end
 
     methods
-        function obj = FixedEffect(x, names, add_intercept, run_categorical_check)
+        function obj = FixedEffect(x, names, add_intercept, run_checks)
             arguments
                 x = [] % Input data.
-                names string = "" % Names of input variables.
-                add_intercept logical = true % If true, include an intercept term.
-                run_categorical_check logical = true % If true, check whether categorical terms are added correctly.
+                names (1,:) string = "" % Names of input variables.
+                add_intercept (1,1) logical = true % If true, include an intercept term.
+                run_checks (1,1) logical = true % If true, check whether categorical terms are added correctly and wheter the data contains nans/infs.
             end
             
             % If no input.
@@ -109,8 +109,11 @@ classdef FixedEffect
                 
                 % Set the matrix
                 obj.matrix = double(x); 
-                if run_categorical_check
+                if run_checks
                     brainstat_utils.check_categorical_variables(obj.matrix, obj.names);
+                    if any(isnan(obj.matrix)) || any(isinf(obj.matrix))
+                        warning('BrainStat:FixedEffect', 'The data contains NaNs or Infs. Model fitting may error.');
+                    end
                 end
             
             % If x is an numeric scalar. 

--- a/brainstat_matlab/stats/@MixedEffect/MixedEffect.m
+++ b/brainstat_matlab/stats/@MixedEffect/MixedEffect.m
@@ -18,10 +18,10 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
 %       to true. 
 %       'name_ran': Names of the random effects. Defaults to 'ran'.
 %       'name_fix': Names of the fixed effects. Defaults to [].
-%       'ranisvar': If true, assumes that input ran is already a variance term.
-%       'run_checks': If true, checks whether categorical variables were
-%       provided as string/cell arrays and whether the input data contains nans/infs. 
-%       Defaults to true. We do not recommend altering this value.
+%       'ranisvar': If true, assumes that input ran is already a variance
+%       term. 'run_checks': If true, checks whether categorical variables
+%       were provided as string/cell arrays. Defaults to true. We do not
+%       recommend altering this value.
 %
 %   Let obj.mean be the mean term, and obj.variance be the variance term.
 %   The following operators are overloaded for random models m1 and m2:
@@ -154,9 +154,6 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
                     % Compute the variance and set it. 
                     if R.run_checks
                         brainstat_utils.check_categorical_variables(ran, R.name_ran);
-                        if any(isnan(double(ran(:)))) || any(isinf(double(ran(:))))
-                            warning('BrainStat:MixedEffect', 'Random term contains NaN or Inf values. This may cause errors in model fitting.');
-                        end
                     end
                     v = double(ran)*double(ran)';
                     obj.variance = FixedEffect(v(:), R.name_ran, false, false);

--- a/brainstat_matlab/stats/@MixedEffect/MixedEffect.m
+++ b/brainstat_matlab/stats/@MixedEffect/MixedEffect.m
@@ -154,7 +154,7 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
                     % Compute the variance and set it. 
                     if R.run_checks
                         brainstat_utils.check_categorical_variables(ran, R.name_ran);
-                        if any(isnan(double(ran))) || any(isinf(double(ran)))
+                        if any(isnan(double(ran(:)))) || any(isinf(double(ran(:))))
                             warning('BrainStat:MixedEffect', 'Random term contains NaN or Inf values. This may cause errors in model fitting.');
                         end
                     end

--- a/brainstat_matlab/stats/@MixedEffect/MixedEffect.m
+++ b/brainstat_matlab/stats/@MixedEffect/MixedEffect.m
@@ -19,9 +19,9 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
 %       'name_ran': Names of the random effects. Defaults to 'ran'.
 %       'name_fix': Names of the fixed effects. Defaults to [].
 %       'ranisvar': If true, assumes that input ran is already a variance term.
-%       'run_categorical_check': If true, checks whether categorical variables were
-%       provided as string/cell arrays. Defaults to true. We do not recommend altering
-%       this value.
+%       'run_checks': If true, checks whether categorical variables were
+%       provided as string/cell arrays and whether the input data contains nans/infs. 
+%       Defaults to true. We do not recommend altering this value.
 %
 %   Let obj.mean be the mean term, and obj.variance be the variance term.
 %   The following operators are overloaded for random models m1 and m2:
@@ -101,7 +101,7 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
             p = inputParser;
             addOptional(p,'add_identity', true, @islogical)
             addOptional(p,'add_intercept', true, @islogical);
-            addOptional(p,'run_categorical_check', true, @islogical);
+            addOptional(p,'run_checks', true, @islogical);
             addOptional(p,'name_ran', 'ran', @(x) ischar(x) || isempty(x));
             addOptional(p,'name_fix', [], @(x) ischar(x) || iscell(x) || isstring(x) || isempty(x))
             addOptional(p,'ranisvar', [], @(x)(islogical(x) || x == 0 || x == 1) && numel(x) == 1);
@@ -152,8 +152,11 @@ classdef (InferiorClasses = {?FixedEffect}) MixedEffect
                     end
                     
                     % Compute the variance and set it. 
-                    if R.run_categorical_check
+                    if R.run_checks
                         brainstat_utils.check_categorical_variables(ran, R.name_ran);
+                        if any(isnan(double(ran))) || any(isinf(double(ran)))
+                            warning('BrainStat:MixedEffect', 'Random term contains NaN or Inf values. This may cause errors in model fitting.');
+                        end
                     end
                     v = double(ran)*double(ran)';
                     obj.variance = FixedEffect(v(:), R.name_ran, false, false);

--- a/brainstat_matlab/stats/@MixedEffect/minus.m
+++ b/brainstat_matlab/stats/@MixedEffect/minus.m
@@ -22,5 +22,5 @@ end
 
 s = MixedEffect(m1.variance - m2.variance, m1.mean - m2.mean, ...
     'ranisvar', true, 'add_identity', false, 'add_intercept', false, ...
-    'run_categorical_check', false);
+    'run_checks', false);
 s = s.set_identity_last();

--- a/brainstat_matlab/stats/@MixedEffect/mtimes.m
+++ b/brainstat_matlab/stats/@MixedEffect/mtimes.m
@@ -68,7 +68,7 @@ if ~isempty(N)
 end
 
 s = MixedEffect(variance,mean, 'ranisvar', true, 'add_identity', false, 'add_intercept', false, ...
-    'run_categorical_check', false);
+    'run_checks', false);
 s = s.set_identity_last();
 
 return

--- a/brainstat_matlab/stats/@MixedEffect/plus.m
+++ b/brainstat_matlab/stats/@MixedEffect/plus.m
@@ -22,5 +22,5 @@ end
 
 s = MixedEffect(m1.variance + m2.variance, m1.mean + m2.mean, ...
     'ranisvar', true, 'add_identity', false, 'add_intercept', false, ...
-    'run_categorical_check', false);
+    'run_checks', false);
 s = s.set_identity_last();


### PR DESCRIPTION
This PR adds a warning thrown if input to the `FixedEffect`/`MixedEffect` classes contains `NaNs` or `Infs`.  