### PR TITLE
Fix Dependabot Jinja2 update issue: update Sphinx and Jinja2 versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
-Sphinx==3.5.4
+Sphinx>=4.0,<8.0
 sphinxcontrib-matlabdomain
 sphinx_rtd_theme
 sphinx-gallery
 plotly
 wordcloud
-jinja2<3.1
+jinja2>=3.0
 -r ../requirements.txt


### PR DESCRIPTION
- Update Sphinx from ==3.5.4 to >=4.0,<8.0
- Update jinja2 from <3.1 to >=3.0
- Fixes #371