### PR TITLE
Fix yeo7 off-by-1 indexing and MATLAB column_vector compatibility

### DIFF
--- a/brainstat/stats/SLM.py
+++ b/brainstat/stats/SLM.py
@@ -322,7 +322,11 @@ class SLM:
                         )
                         yeo_names, _ = fetch_yeo_networks_metadata(7)
                         yeo_names.insert(0, "Undefined")
-                        yeo7_index = yeo7[self.P["peak"]["vertid"][i]]
+                        # vertid is stored as 1-based (inherited from SurfStat /
+                        # MATLAB conventions in peak_clus); subtract 1 before
+                        # indexing the 0-based yeo7 array (see #347).
+                        vertid = self.P["peak"]["vertid"][i]
+                        yeo7_index = yeo7[vertid - 1] if vertid is not None else None
                         if "yeo7" not in self.P["peak"]:
                             self.P["peak"]["yeo7"] = []
                         self.P["peak"]["yeo7"].append(np.take(yeo_names, yeo7_index))

--- a/brainstat_matlab/stats/@SLM/peak_clus.m
+++ b/brainstat_matlab/stats/@SLM/peak_clus.m
@@ -157,8 +157,10 @@ end
 
 function v_col = column_vector(v)
 % Converts the input vector to a column vector.
-arguments
-    v {mustBeVector}
+% Note: mustBeVector was introduced in MATLAB R2020b; an explicit check
+% is used here to keep compatibility with R2019b and R2020a (see #285).
+if ~isempty(v) && ~isvector(v)
+    error('column_vector:NotAVector', 'Input must be a vector.');
 end
 v_col = v(:);
 end


### PR DESCRIPTION
## Summary
- `SLM._surfstat_to_brainstat_rft` was indexing the 0-based `yeo7` array with the 1-based `vertid` produced by `peak_clus`, causing an `IndexError` when a peak landed on the last mesh vertex and silently mis-labeling Yeo networks for every other peak. Subtract 1 before indexing. Closes #347.
- `column_vector` (helper in `peak_clus.m`) used the `mustBeVector` validator, which is only available in MATLAB R2020b+. Replaced with an explicit `isvector` check so R2019b/R2020a still work. Closes #285.

## Test plan
- [ ] Run the Python test suite (`pytest brainstat/tests`) on a build that exercises RFT correction with at least one peak.
- [ ] Smoke-test in MATLAB R2020a: call `SLM.fit` on the standard tutorial example and confirm `peak_clus` returns without error.
- [ ] Re-run the original failing case from #347 (peak on the final vertex of the mesh) and confirm `_surfstat_to_brainstat_rft` completes and assigns a sensible Yeo7 label.