### PR TITLE
Fix CI (Python + MATLAB) and three small bugs in stats

### DIFF
--- a/.github/workflows/MATLAB_unittests.yml
+++ b/.github/workflows/MATLAB_unittests.yml
@@ -59,8 +59,11 @@ jobs:
       with:
         # Configure MATLAB's Python interpreter explicitly before running the
         # tests; otherwise test_precomputed/load_pkl errors with
-        # MATLAB:Python:PythonUnavailable on the GitHub runners.
+        # MATLAB:Python:PythonUnavailable on the GitHub runners. Also need to
+        # add brainstat_matlab to the MATLAB path explicitly — run-tests v2
+        # used to do this via source-folder, but run-command does not.
         command: |
+          addpath(genpath('brainstat_matlab'));
           pyenv('Version', '${{ steps.setup-python.outputs.python-path }}');
           results = runtests('brainstat_matlab', 'IncludeSubfolders', true);
           if any([results.Failed]); error('%d MATLAB test(s) failed.', sum([results.Failed])); end

--- a/.github/workflows/MATLAB_unittests.yml
+++ b/.github/workflows/MATLAB_unittests.yml
@@ -7,37 +7,60 @@ on:
     paths:
       - brainstat_matlab/*
       - '**.m'
+      - .github/workflows/MATLAB_unittests.yml
   pull_request:
     paths:
       - brainstat_matlab/*
       - '**.m'
+      - .github/workflows/MATLAB_unittests.yml
 
 jobs:
   matlab_unit_test:
     strategy:
       fail-fast: false
       matrix:
-        matlab-version: [R019b, latest]
+        include:
+          - matlab-version: R2022a
+            python-version: '3.9'
+          - matlab-version: latest
+            python-version: '3.10'
 
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      id: setup-python
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
-    - name: Install dependencies
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Python dependencies for MATLAB tests
       shell: bash
       run: |
+        python -m pip install --upgrade pip setuptools wheel
+        # numpy + vtk are required by recursive_pkl_conversion in
+        # tests/@test_precomputed/test_precomputed.m, which loads pickle
+        # fixtures via MATLAB's Python bridge.
         python -m pip install numpy vtk
         [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
         git fetch origin test-data-2.0
         git checkout origin/test-data-2.0 -- extern/test-data
         git reset extern/test-data
+
     - name: Install MATLAB
-      uses: matlab-actions/setup-matlab@v0
-    - name: Run tests 
-      uses: matlab-actions/run-tests@v0
+      uses: matlab-actions/setup-matlab@v2
       with:
-        source-folder: brainstat_matlab
+        release: ${{ matrix.matlab-version }}
+
+    - name: Run tests
+      uses: matlab-actions/run-command@v2
+      with:
+        # Configure MATLAB's Python interpreter explicitly before running the
+        # tests; otherwise test_precomputed/load_pkl errors with
+        # MATLAB:Python:PythonUnavailable on the GitHub runners.
+        command: |
+          pyenv('Version', '${{ steps.setup-python.outputs.python-path }}');
+          results = runtests('brainstat_matlab', 'IncludeSubfolders', true);
+          if any([results.Failed]); error('%d MATLAB test(s) failed.', sum([results.Failed])); end

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -16,19 +16,25 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-   
+
     - name: Install Dependencies
       shell: bash
-      run: | 
-        python -m pip install --upgrade pip setuptools
+      run: |
+        # setuptools is no longer bundled by default in Python 3.12 venvs, but
+        # transitive deps (e.g. abagen) still import pkg_resources. Install it
+        # explicitly (both before and after the editable install) so test
+        # collection does not fail with ModuleNotFoundError: pkg_resources.
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel
         [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
         git fetch origin test-data-2.0
         python -m pip install -e .[dev]
+        python -m pip install --upgrade setuptools
 
     - name: Test with pytest
       shell: bash

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -25,16 +25,19 @@ jobs:
     - name: Install Dependencies
       shell: bash
       run: |
-        # setuptools is no longer bundled by default in Python 3.12 venvs, but
-        # transitive deps (e.g. abagen) still import pkg_resources. Install it
-        # explicitly (both before and after the editable install) so test
-        # collection does not fail with ModuleNotFoundError: pkg_resources.
+        # setuptools 81+ no longer ships the legacy `pkg_resources` module on
+        # import, but transitive deps (e.g. abagen 0.1.3 in
+        # brainstat/context/genetics.py) still rely on it. Pin <81 so test
+        # collection succeeds; revisit when abagen drops the pkg_resources
+        # import.
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools wheel
+        python -m pip install 'setuptools<81' wheel
         [[ -z $(git remote show origin | grep "Fetch URL:" | grep git@github.com:MICA-MNI/BrainStat.git) ]] && git config remote.upstream.fetch refs/heads/*:refs/remotes/upstream/* || git config remote.origin.fetch refs/heads/*:refs/origin/upstream/*
         git fetch origin test-data-2.0
         python -m pip install -e .[dev]
-        python -m pip install --upgrade setuptools
+        # Reinstall pinned setuptools in case the editable install pulled it
+        # back up to 81+.
+        python -m pip install --force-reinstall 'setuptools<81'
 
     - name: Test with pytest
       shell: bash

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -11,7 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        # Python 3.12 cannot be exercised while pandas is pinned <2.1 (the
+        # abagen groupby/pkg_resources workaround), because pandas 2.0.x
+        # ships no wheels for 3.12 and cannot be built from source there.
+        # Re-add 3.12 once abagen is patched and the pin is lifted.
+        python-version: ['3.10', '3.11']
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/brainstat/stats/SLM.py
+++ b/brainstat/stats/SLM.py
@@ -1,7 +1,7 @@
 # type: ignore
 """ Standard Linear regression models. """
 import warnings
-from cmath import sqrt
+from math import sqrt
 from pathlib import Path
 from pprint import pformat
 from typing import Optional, Sequence, Tuple, Union
@@ -17,7 +17,7 @@ from nibabel.nifti1 import Nifti1Image
 
 from brainstat._typing import ArrayLike
 from brainstat.datasets import fetch_parcellation, fetch_template_surface
-from brainstat.datasets.base import fetch_template_surface, fetch_yeo_networks_metadata
+from brainstat.datasets.base import fetch_yeo_networks_metadata
 from brainstat.mesh.utils import _mask_edges, mesh_edges
 from brainstat.stats.terms import FixedEffect, MixedEffect
 from brainstat.stats.utils import apply_mask, undo_mask

--- a/brainstat/stats/_t_test.py
+++ b/brainstat/stats/_t_test.py
@@ -1,5 +1,4 @@
 import math
-import sys
 import warnings
 
 import numpy as np
@@ -39,7 +38,7 @@ def _t_test(self) -> None:
         if np.square(np.dot(null_space(self.X).T, c)).sum() / np.square(
             c
         ).sum() > np.spacing(1):
-            sys.exit("Contrast is not estimable :-(")
+            raise ValueError("Contrast is not estimable.")
 
     else:
         c = np.dot(pinvX, self.contrast)

--- a/brainstat/stats/_t_test.py
+++ b/brainstat/stats/_t_test.py
@@ -172,6 +172,8 @@ def _t_test(self) -> None:
                 M[M_ef] = ef_duplicate[:, i]
                 M[M_sse] = sse_matrix.flatten()
 
-                self.t[i] = float(np.sqrt(-np.linalg.det(M) / det_sse / vf))
+                # Use .item() rather than float(): numpy >=2.0 raises
+                # TypeError when float() is applied to size-1 ndarrays.
+                self.t[i] = np.sqrt(-np.linalg.det(M) / det_sse / vf).item()
 
     self.t = np.atleast_2d(self.t)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,12 @@ neurosynth
 nibabel
 nilearn>=0.7.0
 nimare
-numpy>=1.21
-pandas>=1.3,<2.1  # abagen 0.1.3 still calls DataFrame.groupby(axis=...), removed in pandas 2.1
+# numpy and pandas are pinned together: pandas<2.1 is needed because abagen
+# 0.1.3 still calls DataFrame.groupby(axis=...) which pandas 2.1 removed; the
+# resulting pandas 2.0.x is built against numpy 1.x ABI, so numpy must also
+# be <2 to avoid `numpy.dtype size changed` runtime errors.
+numpy>=1.21,<2
+pandas>=1.3,<2.1
 scikit_learn>=1.0
 scipy>=1.7
 statsmodels

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ nibabel
 nilearn>=0.7.0
 nimare
 numpy>=1.21
-pandas>=1.3
+pandas>=1.3,<2.1  # abagen 0.1.3 still calls DataFrame.groupby(axis=...), removed in pandas 2.1
 scikit_learn>=1.0
 scipy>=1.7
 statsmodels

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,10 @@ setuptools.setup(
         "nibabel",
         "nilearn>=0.7.0",
         "nimare",
-        "numpy>=1.21",
-        # pandas 2.1 removed DataFrame.groupby(axis=...), which abagen 0.1.3
-        # still uses; pin <2.1 until upstream is patched.
+        # numpy<2 is required so the pinned pandas<2.1 (whose 2.0.x C
+        # extensions were built against the numpy 1.x ABI) loads cleanly.
+        # See requirements.txt for the abagen-driven rationale.
+        "numpy>=1.21,<2",
         "pandas>=1.3,<2.1",
         "scikit_learn>=1.0",
         "scipy>=1.7",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ setuptools.setup(
         "nilearn>=0.7.0",
         "nimare",
         "numpy>=1.21",
-        "pandas>=1.3",
+        # pandas 2.1 removed DataFrame.groupby(axis=...), which abagen 0.1.3
+        # still uses; pin <2.1 until upstream is patched.
+        "pandas>=1.3,<2.1",
         "scikit_learn>=1.0",
         "scipy>=1.7",
         "templateflow",


### PR DESCRIPTION
## Summary

Brings CI back to green (Python + MATLAB suites have been red on master) and folds in three high-severity correctness fixes from a recent audit. All 9 required checks now pass on this branch.

### CI

**Python tests** (`unittests` matrix) — were aborting at test collection with `ModuleNotFoundError: No module named 'pkg_resources'`. Investigation produced a chain of issues:
1. Default setuptools on Python 3.11/3.12 is now ≥81, which dropped `pkg_resources`. abagen 0.1.3 still imports `pkg_resources`.
2. Pinning `setuptools<81` exposed a numpy 2.x regression: `float(size_1_array)` raises `TypeError: only 0-dimensional arrays can be converted to Python scalars`.
3. abagen 0.1.3 also calls `DataFrame.groupby(sid, axis=1)` which pandas 2.1 removed.
4. Pinning `pandas<2.1` resolves to pandas 2.0.x whose C extensions were built against numpy 1.x ABI → `numpy.dtype size changed` at import.
5. pandas 2.0.x has no Python 3.12 wheels and cannot be built from source there.

Fixes:
- Bumped `actions/checkout@v4` and `actions/setup-python@v5`.
- Pinned `setuptools<81` (with re-install after the editable install in case it gets bumped back).
- Pinned `numpy<2,>=1.21` and `pandas<2.1,>=1.3` in both `setup.py` and `requirements.txt` so the entire stack stays on numpy-1.x ABI until abagen drops `pkg_resources`/`groupby(axis=)`.
- Replaced `float(np.sqrt(... / vf))` with `.item()` in `_t_test.py:175` — works on numpy 1.x and 2.x.
- Dropped Python 3.12 from the matrix (incompatible with the `pandas<2.1` pin); added a comment so it can be re-added once abagen is patched.

**MATLAB tests** (`matlab_unit_test` matrix) — every `test_precomputed/*` errored with `MATLAB:Python:PythonUnavailable` because the workflow installed Python 3.8 but never told MATLAB about it via `pyenv`. Plus `matlab-actions/setup-matlab@v0` is end-of-life.
- Bumped to `matlab-actions/setup-matlab@v2` and `matlab-actions/run-command@v2`; `pyenv('Version', ...)` is now called before `runtests`.
- Switching to `run-command` lost the implicit `addpath` from `run-tests`, so added `addpath(genpath('brainstat_matlab'))` explicitly.
- Pair MATLAB versions with compatible Python: `R2022a` ↔ `3.9`, `latest` ↔ `3.10`. Dropped the unsupported `R019b` matrix entry (setup-matlab v2 needs R2020a+).

### Bugs

- `brainstat/stats/SLM.py` — `from cmath import sqrt` was importing the complex square root. Switched to `math.sqrt`.
- `brainstat/stats/SLM.py` — `fetch_template_surface` was being imported twice; kept the higher-level one.
- `brainstat/stats/_t_test.py` — `sys.exit(...)` would kill the host process when contrast is non-estimable. Replaced with `raise ValueError(...)`.

## Test plan
- [x] `python -m pytest brainstat/tests/test_t_test.py` — 16/16 pass locally.
- [x] All 9 CI checks pass: Python 3.10/3.11 × ubuntu/macos/windows, MATLAB R2022a/latest.
- [ ] Lift the numpy/pandas/3.12 pins once abagen drops `pkg_resources` and the `groupby(axis=)` call.

## Follow-ups (not in this PR)
- File an upstream issue against abagen tracking the `pkg_resources` and `groupby(axis=)` removals so the pins here can come off.
- Consider re-enabling the commented-out `mypy` job after #199 unblocks.